### PR TITLE
Add comprehensive neighbors() tests and improve documentation

### DIFF
--- a/crates/core-ir/src/types.rs
+++ b/crates/core-ir/src/types.rs
@@ -295,8 +295,31 @@ impl Graph {
         self.edges.push(edge);
     }
 
-    /// Iterate over neighbor symbol IDs reachable from `id` via edges whose
+    /// Iterate over neighbor symbol IDs connected to `id` via edges whose
     /// kind is in `kinds`. If `kinds` is empty, all edge kinds match.
+    ///
+    /// # Direction semantics
+    ///
+    /// Traversal is **bidirectional**: a neighbor is any node connected to
+    /// `id` by an edge where `id` appears as either the source (`from`) or
+    /// the target (`to`). This means `neighbors(A, &[])` returns B if there
+    /// is an edge `A → B` *or* `B → A`.
+    ///
+    /// # Unknown nodes
+    ///
+    /// If `id` does not exist in the graph, the iterator yields no items
+    /// (it does **not** return an error).
+    ///
+    /// # Duplicates
+    ///
+    /// If multiple edges connect the same pair of nodes (possibly with
+    /// different kinds), the neighbor's ID appears once per matching edge.
+    /// Callers that need a unique set should collect into a `HashSet`.
+    ///
+    /// # Self-loops
+    ///
+    /// A self-loop (an edge where `from == to == id`) yields the node
+    /// exactly once per matching edge, not twice.
     pub fn neighbors<'a>(
         &'a self,
         id: SymbolId,

--- a/crates/core-ir/tests/core_ir_tests.rs
+++ b/crates/core-ir/tests/core_ir_tests.rs
@@ -193,6 +193,154 @@ fn test_graph_add_and_neighbors() {
     assert_eq!(all.len(), 2);
 }
 
+// ---------------------------------------------------------------------------
+// neighbors() — 5-node fixture graph
+//
+// Fixture topology:
+//
+//   A --Calls--> B --Inherits--> C
+//   |                            ^
+//   +--Contains--> D             |
+//                                |
+//   E --Calls--> E  (self-loop)  |
+//   E --Inherits--> C            |
+//
+// Node A: connected to B (Calls) and D (Contains)
+// Node B: connected to A (Calls, inbound) and C (Inherits)
+// Node C: connected to B (Inherits, inbound) and E (Inherits, inbound)
+// Node D: connected to A (Contains, inbound) — leaf for outgoing
+// Node E: self-loop (Calls) and inherits C
+// ---------------------------------------------------------------------------
+
+/// Build the standard 5-node fixture graph used by neighbors tests.
+fn neighbors_fixture() -> (Graph, SymbolId, SymbolId, SymbolId, SymbolId, SymbolId) {
+    let mut g = Graph::new();
+    let a = g.add_symbol(make_symbol("A", SymbolKind::Class));
+    let b = g.add_symbol(make_symbol("B", SymbolKind::Class));
+    let c = g.add_symbol(make_symbol("C", SymbolKind::Class));
+    let d = g.add_symbol(make_symbol("D", SymbolKind::Method));
+    let e = g.add_symbol(make_symbol("E", SymbolKind::Class));
+
+    g.add_edge(Edge {
+        from: a,
+        to: b,
+        kind: EdgeKind::Calls,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: b,
+        to: c,
+        kind: EdgeKind::Inherits,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: a,
+        to: d,
+        kind: EdgeKind::Contains,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: e,
+        to: e,
+        kind: EdgeKind::Calls,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: e,
+        to: c,
+        kind: EdgeKind::Inherits,
+        location: None,
+    });
+
+    (g, a, b, c, d, e)
+}
+
+#[test]
+fn test_neighbors_all_no_filter() {
+    let (g, a, b, _c, _d, _e) = neighbors_fixture();
+
+    // A is connected to B (Calls) and D (Contains) — bidirectional traversal.
+    let mut all_a: Vec<SymbolId> = g.neighbors(a, &[]).collect();
+    all_a.sort_by_key(|id| id.0);
+    let mut expected = vec![b, _d];
+    expected.sort_by_key(|id| id.0);
+    assert_eq!(all_a, expected, "A should see B and D with no filter");
+
+    // B is connected to A (Calls, inbound) and C (Inherits, outbound).
+    let mut all_b: Vec<SymbolId> = g.neighbors(b, &[]).collect();
+    all_b.sort_by_key(|id| id.0);
+    let mut expected_b = vec![a, _c];
+    expected_b.sort_by_key(|id| id.0);
+    assert_eq!(all_b, expected_b, "B should see A and C with no filter");
+}
+
+#[test]
+fn test_neighbors_filter_single_kind() {
+    let (g, a, b, _c, _d, _e) = neighbors_fixture();
+
+    // A --Calls--> B, so filtering by Calls from A yields B.
+    let calls: Vec<SymbolId> = g.neighbors(a, &[EdgeKind::Calls]).collect();
+    assert_eq!(calls, vec![b]);
+
+    // A --Contains--> D, so filtering by Contains from A yields D.
+    let contains: Vec<SymbolId> = g.neighbors(a, &[EdgeKind::Contains]).collect();
+    assert_eq!(contains, vec![_d]);
+}
+
+#[test]
+fn test_neighbors_filter_multiple_kinds() {
+    let (g, _a, _b, c, _d, e) = neighbors_fixture();
+
+    // E has Calls(self) and Inherits(C). Filter by both kinds.
+    let mut multi: Vec<SymbolId> = g
+        .neighbors(e, &[EdgeKind::Calls, EdgeKind::Inherits])
+        .collect();
+    multi.sort_by_key(|id| id.0);
+    // Self-loop yields E twice (from and to), plus C from Inherits.
+    // e.from == e and e.to == e both match, so self-loop produces 2 entries for E.
+    assert!(multi.contains(&e), "E should appear (self-loop via Calls)");
+    assert!(multi.contains(&c), "C should appear (Inherits from E)");
+}
+
+#[test]
+fn test_neighbors_leaf_node() {
+    let (g, _a, _b, _c, d, _e) = neighbors_fixture();
+
+    // D only has an inbound Contains edge from A — bidirectional means we see A.
+    let leaf: Vec<SymbolId> = g.neighbors(d, &[]).collect();
+    assert_eq!(leaf, vec![_a], "D should see A via inbound Contains edge");
+
+    // But if we filter by Calls, D has none.
+    let leaf_calls: Vec<SymbolId> = g.neighbors(d, &[EdgeKind::Calls]).collect();
+    assert!(leaf_calls.is_empty(), "D has no Calls edges");
+}
+
+#[test]
+fn test_neighbors_unknown_node() {
+    let (g, _a, _b, _c, _d, _e) = neighbors_fixture();
+
+    let unknown = SymbolId(999_999);
+    let result: Vec<SymbolId> = g.neighbors(unknown, &[]).collect();
+    assert!(
+        result.is_empty(),
+        "unknown node should yield empty iterator"
+    );
+}
+
+#[test]
+fn test_neighbors_self_loop() {
+    let (g, _a, _b, _c, _d, e) = neighbors_fixture();
+
+    // E --Calls--> E (self-loop). The implementation uses if/else-if, so
+    // a self-loop edge yields the node exactly once (the `from` branch fires).
+    let self_refs: Vec<SymbolId> = g.neighbors(e, &[EdgeKind::Calls]).collect();
+    assert_eq!(
+        self_refs,
+        vec![e],
+        "self-loop should yield the node once per self-referencing edge"
+    );
+}
+
 #[test]
 fn test_merge_determinism() {
     let mut g1 = Graph::new();


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for the `Graph::neighbors()` method and improves its documentation with detailed semantics and behavior specifications.

## Key Changes

- **New test fixture**: Added `neighbors_fixture()` helper that creates a standardized 5-node graph with mixed edge kinds (Calls, Inherits, Contains) for consistent test reuse
- **Comprehensive test suite**: Added 6 new test cases covering:
  - `test_neighbors_all_no_filter`: Bidirectional traversal with no edge kind filtering
  - `test_neighbors_filter_single_kind`: Filtering by a single edge kind
  - `test_neighbors_filter_multiple_kinds`: Filtering by multiple edge kinds simultaneously
  - `test_neighbors_leaf_node`: Behavior on nodes with only inbound edges
  - `test_neighbors_unknown_node`: Graceful handling of non-existent nodes
  - `test_neighbors_self_loop`: Self-loop edge behavior and deduplication
- **Enhanced documentation**: Updated the `neighbors()` method's doc comment with detailed sections covering:
  - Direction semantics (bidirectional traversal)
  - Unknown node handling (returns empty iterator)
  - Duplicate behavior (one entry per matching edge)
  - Self-loop semantics (yields node once per self-referencing edge)

## Implementation Details

The test fixture establishes a clear topology with nodes A, B, C, D, E and edges demonstrating various relationship types. Tests validate that the neighbors iterator correctly handles edge filtering, bidirectional traversal, and edge cases like self-loops and leaf nodes. The documentation clarifies that self-loops yield the node exactly once (via the `from` branch in the if/else-if implementation), not twice.

https://claude.ai/code/session_0183oAquoNub5L51eDYhD7ka