### PR TITLE
Add comprehensive test suite for subgraph_around with CAP-007 reference graph

### DIFF
--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -9,6 +9,19 @@ use core_ir::{EdgeKind, Graph, SymbolId};
 
 /// Extract a subgraph rooted at `root`, traversing up to `depth` hops along
 /// edges whose kind is in `kinds`. If `kinds` is empty, all edge kinds match.
+///
+/// # Edge cases
+///
+/// * `depth = 0` — returns only the root node with no edges.
+/// * `depth = 1` — returns the root plus its immediate neighbors via matching
+///   edge kinds.
+/// * Empty `kinds` slice — follows all edge kinds (no filtering).
+/// * Root not in graph — returns an empty graph (no panic).
+/// * Traversal is **bidirectional**: an edge `A → B` lets BFS reach `A` from
+///   `B` and vice-versa. A leaf node at depth 1 will therefore include its
+///   predecessor.
+/// * The returned graph contains only edges where **both** endpoints are in the
+///   visited set **and** the edge kind matches the filter.
 pub fn subgraph_around(g: &Graph, root: SymbolId, depth: u32, kinds: &[EdgeKind]) -> Graph {
     let mut visited: HashSet<SymbolId> = HashSet::new();
     let mut queue: VecDeque<(SymbolId, u32)> = VecDeque::new();

--- a/crates/query/tests/query_tests.rs
+++ b/crates/query/tests/query_tests.rs
@@ -75,6 +75,182 @@ fn test_subgraph_depth_zero() {
     assert_eq!(sub.edge_count(), 0);
 }
 
+// ---------------------------------------------------------------------------
+// CAP-007: 7-node reference graph for subgraph_around tests
+// ---------------------------------------------------------------------------
+//
+//   A --Calls--> B --Calls--> C --Calls--> D
+//   A --Inherits--> E
+//   B --Contains--> F
+//   C --Inherits--> G
+//
+
+fn cap007_graph() -> (
+    Graph,
+    SymbolId,
+    SymbolId,
+    SymbolId,
+    SymbolId,
+    SymbolId,
+    SymbolId,
+    SymbolId,
+) {
+    let mut g = Graph::new();
+    let a = make_symbol("A", SymbolKind::Class);
+    let b = make_symbol("B", SymbolKind::Class);
+    let c = make_symbol("C", SymbolKind::Class);
+    let d = make_symbol("D", SymbolKind::Class);
+    let e = make_symbol("E", SymbolKind::Class);
+    let f = make_symbol("F", SymbolKind::Class);
+    let node_g = make_symbol("G", SymbolKind::Class);
+
+    let (a_id, b_id, c_id, d_id, e_id, f_id, g_id) =
+        (a.id, b.id, c.id, d.id, e.id, f.id, node_g.id);
+
+    g.add_symbol(a);
+    g.add_symbol(b);
+    g.add_symbol(c);
+    g.add_symbol(d);
+    g.add_symbol(e);
+    g.add_symbol(f);
+    g.add_symbol(node_g);
+
+    g.add_edge(Edge {
+        from: a_id,
+        to: b_id,
+        kind: EdgeKind::Calls,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: b_id,
+        to: c_id,
+        kind: EdgeKind::Calls,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: c_id,
+        to: d_id,
+        kind: EdgeKind::Calls,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: a_id,
+        to: e_id,
+        kind: EdgeKind::Inherits,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: b_id,
+        to: f_id,
+        kind: EdgeKind::Contains,
+        location: None,
+    });
+    g.add_edge(Edge {
+        from: c_id,
+        to: g_id,
+        kind: EdgeKind::Inherits,
+        location: None,
+    });
+
+    (g, a_id, b_id, c_id, d_id, e_id, f_id, g_id)
+}
+
+/// CAP-007 test 1: depth 0 returns only root, no edges.
+#[test]
+fn test_cap007_depth_zero() {
+    let (g, a_id, ..) = cap007_graph();
+    let sub = subgraph_around(&g, a_id, 0, &[]);
+    assert_eq!(sub.symbol_count(), 1);
+    assert!(sub.symbols.contains_key(&a_id));
+    assert_eq!(sub.edge_count(), 0);
+}
+
+/// CAP-007 test 2: depth 1 from A returns {A, B, E} with edges {A→B, A→E}.
+#[test]
+fn test_cap007_depth_one() {
+    let (g, a_id, b_id, _, _, e_id, ..) = cap007_graph();
+    let sub = subgraph_around(&g, a_id, 1, &[]);
+    assert_eq!(sub.symbol_count(), 3);
+    assert!(sub.symbols.contains_key(&a_id));
+    assert!(sub.symbols.contains_key(&b_id));
+    assert!(sub.symbols.contains_key(&e_id));
+    assert_eq!(sub.edge_count(), 2);
+}
+
+/// CAP-007 test 3: depth 2 from A returns {A, B, E, C, F} with correct edges.
+#[test]
+fn test_cap007_depth_two() {
+    let (g, a_id, b_id, c_id, _, e_id, f_id, _) = cap007_graph();
+    let sub = subgraph_around(&g, a_id, 2, &[]);
+    assert_eq!(sub.symbol_count(), 5);
+    assert!(sub.symbols.contains_key(&a_id));
+    assert!(sub.symbols.contains_key(&b_id));
+    assert!(sub.symbols.contains_key(&c_id));
+    assert!(sub.symbols.contains_key(&e_id));
+    assert!(sub.symbols.contains_key(&f_id));
+    // Edges: A→B (Calls), A→E (Inherits), B→C (Calls), B→F (Contains)
+    assert_eq!(sub.edge_count(), 4);
+}
+
+/// CAP-007 test 4: depth 2 from A with Calls filter returns {A, B, C}, only Calls edges.
+#[test]
+fn test_cap007_kind_filter_calls() {
+    let (g, a_id, b_id, c_id, ..) = cap007_graph();
+    let sub = subgraph_around(&g, a_id, 2, &[EdgeKind::Calls]);
+    assert_eq!(sub.symbol_count(), 3);
+    assert!(sub.symbols.contains_key(&a_id));
+    assert!(sub.symbols.contains_key(&b_id));
+    assert!(sub.symbols.contains_key(&c_id));
+    assert_eq!(sub.edge_count(), 2);
+    for edge in &sub.edges {
+        assert_eq!(edge.kind, EdgeKind::Calls);
+    }
+}
+
+/// CAP-007 test 5: root not in graph returns empty graph, no panic.
+#[test]
+fn test_cap007_root_not_found() {
+    let (g, ..) = cap007_graph();
+    let missing = SymbolId::from_parts("DoesNotExist", SymbolKind::Class);
+    let sub = subgraph_around(&g, missing, 3, &[]);
+    assert_eq!(sub.symbol_count(), 0);
+    assert_eq!(sub.edge_count(), 0);
+}
+
+/// CAP-007 test 6: leaf node D at depth 1 reaches C (bidirectional traversal).
+#[test]
+fn test_cap007_leaf_as_root() {
+    let (g, _, _, c_id, d_id, ..) = cap007_graph();
+    let sub = subgraph_around(&g, d_id, 1, &[]);
+    // D's only neighbor is C (via the C→D Calls edge, traversed bidirectionally).
+    assert_eq!(sub.symbol_count(), 2);
+    assert!(sub.symbols.contains_key(&d_id));
+    assert!(sub.symbols.contains_key(&c_id));
+    assert_eq!(sub.edge_count(), 1);
+}
+
+/// CAP-007 test 7: edge integrity — no edge references a symbol outside the subgraph.
+#[test]
+fn test_cap007_edge_integrity() {
+    let (g, a_id, ..) = cap007_graph();
+    // Test at several depths to be thorough.
+    for depth in 0..=4 {
+        let sub = subgraph_around(&g, a_id, depth, &[]);
+        for edge in &sub.edges {
+            assert!(
+                sub.symbols.contains_key(&edge.from),
+                "depth {depth}: edge.from {:?} not in subgraph symbols",
+                edge.from
+            );
+            assert!(
+                sub.symbols.contains_key(&edge.to),
+                "depth {depth}: edge.to {:?} not in subgraph symbols",
+                edge.to
+            );
+        }
+    }
+}
+
 #[test]
 fn test_find_by_name() {
     let g = test_graph();


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for the `subgraph_around` function with a new 7-node reference graph (CAP-007) and improves documentation of the function's behavior and edge cases.

## Key Changes

- **New reference graph**: Added `cap007_graph()` helper function that creates a 7-node test graph with mixed edge types (Calls, Inherits, Contains) to serve as a standard reference for subgraph tests.

- **Comprehensive test cases**: Added 7 new tests covering:
  - Depth 0 behavior (root only, no edges)
  - Depth 1 traversal (immediate neighbors)
  - Depth 2 traversal (multi-hop neighbors)
  - Edge kind filtering (Calls-only traversal)
  - Missing root handling (graceful empty graph return)
  - Leaf node traversal (bidirectional edge behavior)
  - Edge integrity validation (no dangling edge references)

- **Enhanced documentation**: Updated `subgraph_around` function documentation with detailed edge case descriptions, including:
  - Behavior at different depth levels
  - Empty kinds slice semantics
  - Bidirectional traversal behavior
  - Edge filtering guarantees

## Notable Implementation Details

The test suite validates that:
- The function handles missing roots without panicking
- Traversal is truly bidirectional (leaf nodes can reach their predecessors)
- Edge filtering correctly excludes edges of non-matching kinds
- All edges in the returned subgraph have both endpoints present in the symbol set
- The function scales correctly across multiple depth levels

https://claude.ai/code/session_01RQ3dFSq647sfYfVwkj5QV2