### PR TITLE
Extract camera and hit-testing logic into dedicated module

### DIFF
--- a/crates/viz/Cargo.toml
+++ b/crates/viz/Cargo.toml
@@ -19,3 +19,4 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 glam = { workspace = true }
+indexmap = { workspace = true }

--- a/crates/viz/src/app.rs
+++ b/crates/viz/src/app.rs
@@ -4,8 +4,9 @@ use std::collections::HashSet;
 
 use core_ir::{EdgeKind, Graph, SymbolId, SymbolKind};
 use egui::{Color32, Pos2, Rect, Stroke, StrokeKind, Vec2};
-use glam::Vec2 as GVec2;
 use layout::Positions;
+
+use crate::camera::{self, Camera2D, NODE_HEIGHT, NODE_WIDTH};
 
 /// Edge kind filter state.
 struct EdgeKindFilter {
@@ -45,37 +46,6 @@ impl EdgeKindFilter {
     }
 }
 
-/// 2D camera for pan and zoom.
-struct Camera2D {
-    offset: Vec2,
-    zoom: f32,
-}
-
-impl Default for Camera2D {
-    fn default() -> Self {
-        Self {
-            offset: Vec2::ZERO,
-            zoom: 1.0,
-        }
-    }
-}
-
-impl Camera2D {
-    /// Transform a world position to screen position.
-    fn world_to_screen(&self, world: GVec2, canvas_center: Pos2) -> Pos2 {
-        let x = canvas_center.x + (world.x + self.offset.x) * self.zoom;
-        let y = canvas_center.y + (world.y + self.offset.y) * self.zoom;
-        Pos2::new(x, y)
-    }
-
-    /// Transform a screen position to world position.
-    fn screen_to_world(&self, screen: Pos2, canvas_center: Pos2) -> GVec2 {
-        let x = (screen.x - canvas_center.x) / self.zoom - self.offset.x;
-        let y = (screen.y - canvas_center.y) / self.zoom - self.offset.y;
-        GVec2::new(x, y)
-    }
-}
-
 /// Main application state.
 pub struct SpaghettiApp {
     graph: Graph,
@@ -85,9 +55,6 @@ pub struct SpaghettiApp {
     edge_filter: EdgeKindFilter,
     search: String,
 }
-
-const NODE_WIDTH: f32 = 120.0;
-const NODE_HEIGHT: f32 = 30.0;
 
 impl SpaghettiApp {
     /// Create a new app with the given graph and pre-computed positions.
@@ -203,7 +170,7 @@ impl SpaghettiApp {
             let scroll_delta = ui.input(|i| i.smooth_scroll_delta.y);
             if scroll_delta != 0.0 {
                 let zoom_factor = 1.0 + scroll_delta * 0.002;
-                self.camera.zoom = (self.camera.zoom * zoom_factor).clamp(0.1, 10.0);
+                self.camera.apply_zoom(zoom_factor);
             }
 
             // Handle pan (drag)
@@ -283,18 +250,7 @@ impl SpaghettiApp {
     /// Hit-test: find which symbol (if any) is under the pointer.
     // TODO: quadtree for efficient hit testing
     fn hit_test(&self, pointer: Option<Pos2>, canvas_center: Pos2) -> Option<SymbolId> {
-        let pointer = pointer?;
-        let world = self.camera.screen_to_world(pointer, canvas_center);
-
-        let half_w = NODE_WIDTH / 2.0;
-        let half_h = NODE_HEIGHT / 2.0;
-
-        for (id, pos) in &self.positions.0 {
-            if (world.x - pos.x).abs() < half_w && (world.y - pos.y).abs() < half_h {
-                return Some(*id);
-            }
-        }
-        None
+        camera::hit_test(&self.camera, &self.positions, pointer, canvas_center)
     }
 }
 

--- a/crates/viz/src/camera.rs
+++ b/crates/viz/src/camera.rs
@@ -1,0 +1,215 @@
+//! 2D camera with pan/zoom and hit-testing.
+//!
+//! Node size is **fixed in world space** — a node always occupies `NODE_WIDTH × NODE_HEIGHT`
+//! world units regardless of zoom. Zoom only changes how large those world units appear on
+//! screen.
+
+use core_ir::SymbolId;
+use glam::Vec2 as GVec2;
+use layout::Positions;
+
+/// Width of a node in world-space units.
+pub const NODE_WIDTH: f32 = 120.0;
+/// Height of a node in world-space units.
+pub const NODE_HEIGHT: f32 = 30.0;
+
+/// Minimum allowed zoom level.
+const ZOOM_MIN: f32 = 0.1;
+/// Maximum allowed zoom level.
+const ZOOM_MAX: f32 = 10.0;
+
+/// 2D camera managing pan (offset) and zoom for the canvas.
+pub struct Camera2D {
+    /// Pan offset in world-space units.
+    pub offset: egui::Vec2,
+    /// Zoom factor, clamped to [`ZOOM_MIN`, `ZOOM_MAX`].
+    pub zoom: f32,
+}
+
+impl Default for Camera2D {
+    fn default() -> Self {
+        Self {
+            offset: egui::Vec2::ZERO,
+            zoom: 1.0,
+        }
+    }
+}
+
+impl Camera2D {
+    /// Transform a world position to a screen position.
+    ///
+    /// `canvas_center` is the pixel center of the drawing area.
+    pub fn world_to_screen(&self, world: GVec2, canvas_center: egui::Pos2) -> egui::Pos2 {
+        let x = canvas_center.x + (world.x + self.offset.x) * self.zoom;
+        let y = canvas_center.y + (world.y + self.offset.y) * self.zoom;
+        egui::Pos2::new(x, y)
+    }
+
+    /// Transform a screen position back to a world position.
+    ///
+    /// This is the mathematical inverse of [`world_to_screen`](Self::world_to_screen).
+    pub fn screen_to_world(&self, screen: egui::Pos2, canvas_center: egui::Pos2) -> GVec2 {
+        let x = (screen.x - canvas_center.x) / self.zoom - self.offset.x;
+        let y = (screen.y - canvas_center.y) / self.zoom - self.offset.y;
+        GVec2::new(x, y)
+    }
+
+    /// Apply a zoom delta, keeping the zoom clamped to [0.1, 10.0].
+    pub fn apply_zoom(&mut self, factor: f32) {
+        self.zoom = (self.zoom * factor).clamp(ZOOM_MIN, ZOOM_MAX);
+    }
+}
+
+/// Identify which node (if any) is under `pointer_screen`.
+///
+/// This is a **pure function** — it has no GUI dependencies beyond the position types.
+/// Node bounding boxes are axis-aligned rectangles of `NODE_WIDTH × NODE_HEIGHT` in world
+/// space.
+///
+/// Returns `None` when `pointer_screen` is `None` or no node is hit.
+pub fn hit_test(
+    camera: &Camera2D,
+    positions: &Positions,
+    pointer_screen: Option<egui::Pos2>,
+    canvas_center: egui::Pos2,
+) -> Option<SymbolId> {
+    let pointer = pointer_screen?;
+    let world = camera.screen_to_world(pointer, canvas_center);
+
+    let half_w = NODE_WIDTH / 2.0;
+    let half_h = NODE_HEIGHT / 2.0;
+
+    for (id, pos) in &positions.0 {
+        if (world.x - pos.x).abs() < half_w && (world.y - pos.y).abs() < half_h {
+            return Some(*id);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    /// Helper: canvas center at (400, 300).
+    fn center() -> egui::Pos2 {
+        egui::Pos2::new(400.0, 300.0)
+    }
+
+    /// 1. Roundtrip: world_to_screen then screen_to_world returns the original point.
+    #[test]
+    fn roundtrip_world_screen_world() {
+        let cam = Camera2D {
+            offset: egui::Vec2::new(10.0, -20.0),
+            zoom: 2.5,
+        };
+        let original = GVec2::new(42.0, -17.0);
+        let screen = cam.world_to_screen(original, center());
+        let back = cam.screen_to_world(screen, center());
+        assert!((back.x - original.x).abs() < 1e-4, "x mismatch");
+        assert!((back.y - original.y).abs() < 1e-4, "y mismatch");
+    }
+
+    /// 2. Identity: at zoom=1 offset=0, world (0,0) maps to canvas center.
+    #[test]
+    fn identity_at_default_camera() {
+        let cam = Camera2D::default();
+        let screen = cam.world_to_screen(GVec2::ZERO, center());
+        assert!((screen.x - center().x).abs() < 1e-4);
+        assert!((screen.y - center().y).abs() < 1e-4);
+    }
+
+    /// 3. Zoom scaling: doubling zoom doubles the screen offset from center.
+    #[test]
+    fn zoom_scales_screen_offset() {
+        let world = GVec2::new(50.0, 50.0);
+
+        let cam1 = Camera2D {
+            zoom: 1.0,
+            ..Default::default()
+        };
+        let cam2 = Camera2D {
+            zoom: 2.0,
+            ..Default::default()
+        };
+
+        let s1 = cam1.world_to_screen(world, center());
+        let s2 = cam2.world_to_screen(world, center());
+
+        let dx1 = s1.x - center().x;
+        let dx2 = s2.x - center().x;
+        assert!((dx2 - 2.0 * dx1).abs() < 1e-4, "x offset should double");
+
+        let dy1 = s1.y - center().y;
+        let dy2 = s2.y - center().y;
+        assert!((dy2 - 2.0 * dy1).abs() < 1e-4, "y offset should double");
+    }
+
+    /// 4. Hit-test hits a node at the node's center.
+    #[test]
+    fn hit_test_on_node_center() {
+        let cam = Camera2D::default();
+        let node_world = GVec2::new(100.0, 50.0);
+        let id = SymbolId(1);
+
+        let mut map = IndexMap::new();
+        map.insert(id, node_world);
+        let positions = Positions(map);
+
+        let screen = cam.world_to_screen(node_world, center());
+        let result = hit_test(&cam, &positions, Some(screen), center());
+        assert_eq!(result, Some(id));
+    }
+
+    /// 5. Hit-test misses when pointer is outside the node.
+    #[test]
+    fn hit_test_miss_outside_node() {
+        let cam = Camera2D::default();
+        let node_world = GVec2::new(100.0, 50.0);
+        let id = SymbolId(1);
+
+        let mut map = IndexMap::new();
+        map.insert(id, node_world);
+        let positions = Positions(map);
+
+        // Place pointer well outside node bounds (200 units away in world space)
+        let far = cam.world_to_screen(GVec2::new(300.0, 50.0), center());
+        let result = hit_test(&cam, &positions, Some(far), center());
+        assert_eq!(result, None);
+    }
+
+    /// 6. Hit-test works correctly at a non-default zoom level.
+    #[test]
+    fn hit_test_at_zoomed_level() {
+        let cam = Camera2D {
+            zoom: 3.0,
+            ..Default::default()
+        };
+        let node_world = GVec2::new(0.0, 0.0);
+        let id = SymbolId(42);
+
+        let mut map = IndexMap::new();
+        map.insert(id, node_world);
+        let positions = Positions(map);
+
+        // Slightly inside the node boundary (half_w = 60, so 59 units in world space)
+        let near_edge = cam.world_to_screen(GVec2::new(59.0, 14.0), center());
+        assert_eq!(
+            hit_test(&cam, &positions, Some(near_edge), center()),
+            Some(id)
+        );
+
+        // Just outside (61 units in world space, past the 60-unit half-width)
+        let outside = cam.world_to_screen(GVec2::new(61.0, 0.0), center());
+        assert_eq!(hit_test(&cam, &positions, Some(outside), center()), None);
+    }
+
+    /// 7. Hit-test returns None when pointer is None.
+    #[test]
+    fn hit_test_none_pointer() {
+        let cam = Camera2D::default();
+        let positions = Positions(IndexMap::new());
+        assert_eq!(hit_test(&cam, &positions, None, center()), None);
+    }
+}

--- a/crates/viz/src/main.rs
+++ b/crates/viz/src/main.rs
@@ -3,6 +3,7 @@
 //! Usage: `spaghetti <path-to-compile_commands.json>`
 
 mod app;
+mod camera;
 
 use anyhow::{bail, Result};
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary
Refactored the 2D camera system and hit-testing logic from `app.rs` into a new dedicated `camera.rs` module. This improves code organization, testability, and reusability by separating camera concerns from the main application state.

## Key Changes
- **New `camera.rs` module** with:
  - `Camera2D` struct managing pan (offset) and zoom with configurable limits (0.1–10.0)
  - `world_to_screen()` and `screen_to_world()` coordinate transformation methods
  - `apply_zoom()` method for safe zoom factor application
  - `hit_test()` pure function for node selection (no GUI dependencies)
  - Node dimension constants (`NODE_WIDTH`, `NODE_HEIGHT`) moved to module level
  - Comprehensive test suite (7 tests) covering roundtrips, zoom scaling, and hit-testing edge cases

- **Refactored `app.rs`**:
  - Removed `Camera2D` struct definition and moved to `camera` module
  - Removed `NODE_WIDTH` and `NODE_HEIGHT` constants (now imported from `camera`)
  - Replaced inline `hit_test()` method with call to `camera::hit_test()`
  - Updated zoom handling to use `camera.apply_zoom()` method
  - Added import of camera module and types

- **Updated `Cargo.toml`**: Added `indexmap` workspace dependency (used in tests)

## Notable Implementation Details
- Camera transformations are mathematically inverse operations, verified by roundtrip tests
- Hit-testing uses axis-aligned bounding boxes (half-width/half-height checks) in world space
- The `hit_test()` function is pure and dependency-free, accepting only position types—enabling easier testing and potential reuse
- Zoom is clamped to [0.1, 10.0] range to prevent degenerate states
- All coordinate transformations account for canvas center, offset, and zoom factor

https://claude.ai/code/session_01Jej28jjKi3qGLzd2ZoRbz2