### PR TITLE
Add container node collapse/expand with visual grouping

### DIFF
--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -69,6 +69,10 @@ pub struct ForceParams {
     /// parent-directory attraction is half of same-directory attraction.
     #[serde(default = "default_location_falloff")]
     pub location_falloff: f32,
+    /// Strength of the containment force that pulls children of an expanded
+    /// container toward their siblings' centroid. `0.0` disables.
+    #[serde(default = "default_containment_strength")]
+    pub containment_strength: f32,
 }
 
 fn default_location_strength() -> f32 {
@@ -77,6 +81,10 @@ fn default_location_strength() -> f32 {
 
 fn default_location_falloff() -> f32 {
     0.5
+}
+
+fn default_containment_strength() -> f32 {
+    0.02
 }
 
 impl Default for ForceParams {
@@ -158,6 +166,7 @@ impl Default for ForceParams {
             edge_params,
             location_strength: default_location_strength(),
             location_falloff: default_location_falloff(),
+            containment_strength: default_containment_strength(),
         }
     }
 }
@@ -190,6 +199,18 @@ pub struct LayoutState {
     dir_groups: Vec<Vec<Vec<usize>>>,
     /// Maximum directory depth across all nodes (cached for force scaling).
     max_dir_depth: usize,
+    /// Maps each node index to its parent container index (via Contains edges).
+    parent_of: Vec<Option<usize>>,
+    /// Maps each container node index to its children indices.
+    children_of: Vec<Vec<usize>>,
+    /// Set of node indices that are containers (have >=1 Contains-child).
+    containers: HashSet<usize>,
+    /// Which containers are currently expanded (children visible).
+    expanded: HashSet<usize>,
+    /// Nodes hidden by collapse (tracked separately from file-tree hidden).
+    collapse_hidden: HashSet<usize>,
+    /// Nodes hidden by external callers (file-tree visibility).
+    external_hidden: HashSet<usize>,
 }
 
 impl LayoutState {
@@ -250,6 +271,30 @@ impl LayoutState {
         let dir_groups = build_dir_groups(graph, &ids, &id_to_idx);
         let max_dir_depth = dir_groups.len().saturating_sub(1);
 
+        // Build containment hierarchy from Contains edges.
+        let mut parent_of = vec![None; n];
+        let mut children_of = vec![Vec::new(); n];
+        let mut containers = HashSet::new();
+        for &(from, to, kind) in &edge_pairs {
+            if kind == EdgeKind::Contains {
+                parent_of[to] = Some(from);
+                children_of[from].push(to);
+                containers.insert(from);
+            }
+        }
+
+        // Default: all containers collapsed. Hide their children.
+        let expanded = HashSet::new();
+        let mut collapse_hidden = HashSet::new();
+        for &c in &containers {
+            for &child in &children_of[c] {
+                collapse_hidden.insert(child);
+            }
+        }
+
+        // Combine collapse-hidden into the main hidden set.
+        let hidden = collapse_hidden.clone();
+
         Self {
             ids,
             positions,
@@ -261,9 +306,15 @@ impl LayoutState {
             params,
             degrees,
             total_steps: 0,
-            hidden: HashSet::new(),
+            hidden,
             dir_groups,
             max_dir_depth,
+            parent_of,
+            children_of,
+            containers,
+            expanded,
+            collapse_hidden,
+            external_hidden: HashSet::new(),
         }
     }
 
@@ -405,6 +456,40 @@ impl LayoutState {
                 // Scale by 1/sqrt(degree) at each endpoint so hubs stay calm.
                 forces[from] += dir * displacement / self.degrees[from].sqrt();
                 forces[to] -= dir * displacement / self.degrees[to].sqrt();
+            }
+
+            // Containment force: for expanded containers, pull children
+            // toward their siblings' centroid so they stay clustered.
+            if p.containment_strength > 0.0 {
+                for &c in &self.containers {
+                    if !self.expanded.contains(&c) {
+                        continue;
+                    }
+                    let children = &self.children_of[c];
+                    if children.len() < 2 {
+                        continue;
+                    }
+                    // Compute centroid of visible children.
+                    let mut centroid = Vec2::ZERO;
+                    let mut count = 0u32;
+                    for &child in children {
+                        if !self.hidden.contains(&child) {
+                            centroid += self.positions[child];
+                            count += 1;
+                        }
+                    }
+                    if count < 2 {
+                        continue;
+                    }
+                    centroid /= count as f32;
+
+                    for &child in children {
+                        if !self.hidden.contains(&child) {
+                            forces[child] +=
+                                (centroid - self.positions[child]) * p.containment_strength;
+                        }
+                    }
+                }
             }
 
             // Location-affinity force: pull nodes toward their directory
@@ -604,19 +689,145 @@ impl LayoutState {
         let _ = n;
     }
 
-    /// Set which symbols are hidden from the simulation.
+    /// Set which symbols are hidden from the simulation (by external callers,
+    /// e.g. file-tree visibility toggles).
     ///
     /// Hidden nodes are excluded from all force computations (repulsion,
     /// attraction, gravity, location affinity) and their positions/velocities
     /// are not updated. They still occupy their slot so indices remain stable.
+    ///
+    /// This merges with collapse-hidden state — nodes hidden by either
+    /// mechanism are excluded.
     pub fn set_hidden(&mut self, ids: &[SymbolId]) {
-        self.hidden.clear();
+        self.external_hidden.clear();
         for id in ids {
             if let Some(&idx) = self.id_to_idx.get(id) {
-                self.hidden.insert(idx);
+                self.external_hidden.insert(idx);
             }
         }
+        self.rebuild_hidden();
         self.reheat();
+    }
+
+    /// Rebuild the effective hidden set from collapse + external sources.
+    fn rebuild_hidden(&mut self) {
+        self.hidden = &self.collapse_hidden | &self.external_hidden;
+    }
+
+    /// Collapse a container node: hide all its children.
+    ///
+    /// Children's positions are moved to the parent's position so they
+    /// animate outward on subsequent expand.
+    pub fn collapse(&mut self, id: SymbolId) {
+        let Some(&idx) = self.id_to_idx.get(&id) else {
+            return;
+        };
+        if !self.containers.contains(&idx) {
+            return;
+        }
+        self.expanded.remove(&idx);
+        let parent_pos = self.positions[idx];
+        for &child in &self.children_of[idx] {
+            self.collapse_hidden.insert(child);
+            self.positions[child] = parent_pos;
+            self.velocities[child] = Vec2::ZERO;
+        }
+        self.rebuild_hidden();
+        self.reheat();
+    }
+
+    /// Expand a container node: show all its children.
+    ///
+    /// Children are scattered in a small radius around the parent so they
+    /// animate into place.
+    pub fn expand(&mut self, id: SymbolId) {
+        let Some(&idx) = self.id_to_idx.get(&id) else {
+            return;
+        };
+        if !self.containers.contains(&idx) {
+            return;
+        }
+        self.expanded.insert(idx);
+        let parent_pos = self.positions[idx];
+        let children = self.children_of[idx].clone();
+        for (i, &child) in children.iter().enumerate() {
+            self.collapse_hidden.remove(&child);
+            // Scatter children in a circle around the parent.
+            let angle = (i as f32) * std::f32::consts::TAU / children.len().max(1) as f32;
+            let offset = Vec2::new(angle.cos(), angle.sin()) * 50.0;
+            self.positions[child] = parent_pos + offset;
+            self.velocities[child] = Vec2::ZERO;
+        }
+        self.rebuild_hidden();
+        self.reheat();
+    }
+
+    /// Toggle a container between collapsed and expanded.
+    pub fn toggle_expand(&mut self, id: SymbolId) {
+        let Some(&idx) = self.id_to_idx.get(&id) else {
+            return;
+        };
+        if self.expanded.contains(&idx) {
+            self.collapse(id);
+        } else {
+            self.expand(id);
+        }
+    }
+
+    /// Check whether a container is currently expanded.
+    pub fn is_expanded(&self, id: SymbolId) -> bool {
+        let Some(&idx) = self.id_to_idx.get(&id) else {
+            return false;
+        };
+        self.expanded.contains(&idx)
+    }
+
+    /// Check whether a symbol is a container (has children via Contains edges).
+    pub fn is_container(&self, id: SymbolId) -> bool {
+        let Some(&idx) = self.id_to_idx.get(&id) else {
+            return false;
+        };
+        self.containers.contains(&idx)
+    }
+
+    /// Return the children of a container node.
+    pub fn children_of(&self, id: SymbolId) -> Vec<SymbolId> {
+        let Some(&idx) = self.id_to_idx.get(&id) else {
+            return Vec::new();
+        };
+        self.children_of[idx].iter().map(|&i| self.ids[i]).collect()
+    }
+
+    /// Return the parent container of a node, if any.
+    pub fn parent_of(&self, id: SymbolId) -> Option<SymbolId> {
+        let &idx = self.id_to_idx.get(&id)?;
+        self.parent_of[idx].map(|p| self.ids[p])
+    }
+
+    /// Collapse all container nodes.
+    pub fn collapse_all(&mut self) {
+        let container_ids: Vec<SymbolId> =
+            self.containers.iter().map(|&idx| self.ids[idx]).collect();
+        for id in container_ids {
+            self.collapse(id);
+        }
+    }
+
+    /// Expand all container nodes.
+    pub fn expand_all(&mut self) {
+        let container_ids: Vec<SymbolId> =
+            self.containers.iter().map(|&idx| self.ids[idx]).collect();
+        for id in container_ids {
+            self.expand(id);
+        }
+    }
+
+    /// Return all symbol IDs that are currently hidden due to collapsed containers.
+    pub fn collapsed_hidden_ids(&self) -> Vec<SymbolId> {
+        self.collapse_hidden
+            .iter()
+            .map(|&idx| self.ids[idx])
+            .collect()
     }
 }
 

--- a/crates/viz/src/app.rs
+++ b/crates/viz/src/app.rs
@@ -13,7 +13,7 @@ use tracing::Level;
 
 use crate::file_tree::FileTree;
 
-use crate::camera::{self, Camera2D};
+use crate::camera::Camera2D;
 use crate::fps::FpsCounter;
 use crate::log_capture::LogBuffer;
 use crate::progress::{ProgressMessage, ProgressState};
@@ -146,6 +146,11 @@ pub struct SpaghettiApp {
 
     // -- FPS counter --
     pub(crate) fps: FpsCounter,
+
+    // -- Compound node state --
+    /// Screen-space rects of expanded containers (computed each frame for
+    /// hit-testing). Pairs of (container SymbolId, screen Rect).
+    pub(crate) container_rects: Vec<(SymbolId, egui::Rect)>,
 }
 
 impl SpaghettiApp {
@@ -195,7 +200,18 @@ impl SpaghettiApp {
             cancel_tx: None,
             pending_file_dialog: None,
             fps: FpsCounter::new(60),
+            container_rects: Vec::new(),
         }
+    }
+
+    /// Recompute the effective hidden-symbols set by merging file-tree
+    /// visibility with layout collapse state.
+    pub(crate) fn sync_hidden_symbols(&mut self) {
+        let file_hidden = self.file_tree.hidden_symbols();
+        let collapse_hidden = self.layout_state.collapsed_hidden_ids();
+        self.hidden_symbols = &file_hidden | &collapse_hidden.into_iter().collect();
+        let hidden_vec: Vec<_> = file_hidden.into_iter().collect();
+        self.layout_state.set_hidden(&hidden_vec);
     }
 
     /// Snapshot the current view state for serialization.
@@ -365,17 +381,16 @@ impl SpaghettiApp {
                     layout_state,
                 } => {
                     self.file_tree = FileTree::from_graph(&graph);
-                    self.hidden_symbols = self.file_tree.hidden_symbols();
                     self.graph = *graph;
                     self.layout_state = *layout_state;
-                    let hidden_vec: Vec<_> = self.hidden_symbols.iter().copied().collect();
-                    self.layout_state.set_hidden(&hidden_vec);
+                    self.sync_hidden_symbols();
                     self.positions = self.layout_state.positions();
                     self.selection = None;
                     self.camera = Camera2D::default();
                     self.dragging = None;
                     self.auto_fitted = false;
                     self.frame_count = 0;
+                    self.container_rects.clear();
                     self.finish_indexing();
                 }
                 ProgressMessage::Failed(ref err) => {
@@ -397,26 +412,6 @@ impl SpaghettiApp {
         self.progress_state = None;
         self.progress_rx = None;
         self.cancel_tx = None;
-    }
-
-    /// Hit-test: find which symbol (if any) is under the pointer.
-    pub(crate) fn hit_test(
-        &self,
-        pointer: Option<egui::Pos2>,
-        canvas_center: egui::Pos2,
-    ) -> Option<SymbolId> {
-        let radius = if self.render.circle_mode {
-            Some(self.render.circle_radius)
-        } else {
-            None
-        };
-        camera::hit_test(
-            &self.camera,
-            &self.positions,
-            pointer,
-            canvas_center,
-            radius,
-        )
     }
 
     /// Draw the progress overlay (modal).

--- a/crates/viz/src/panels/canvas.rs
+++ b/crates/viz/src/panels/canvas.rs
@@ -1,11 +1,20 @@
 //! Central canvas panel: node and edge rendering, pan/zoom, dragging, selection.
 
+use std::collections::{HashMap, HashSet};
+
 use egui::{Color32, Rect, Stroke, StrokeKind, Vec2};
 use glam::Vec2 as GVec2;
+
+use core_ir::SymbolId;
 
 use crate::app::{SpaghettiApp, ENERGY_THRESHOLD};
 use crate::camera::{NODE_HEIGHT, NODE_WIDTH};
 use crate::fps::paint_fps_overlay;
+
+/// Scale factor for collapsed container nodes (slightly larger than normal).
+const COLLAPSED_CONTAINER_SCALE: f32 = 1.3;
+/// World-space padding around children for expanded container backgrounds.
+const CONTAINER_PADDING: f32 = 30.0;
 
 impl SpaghettiApp {
     /// Draw the central canvas: nodes and edges with interactive dragging.
@@ -27,7 +36,9 @@ impl SpaghettiApp {
 
             // Drag started: determine whether we are dragging a node or panning.
             if response.drag_started_by(egui::PointerButton::Primary) {
-                if let Some(hit) = self.hit_test(response.interact_pointer_pos(), canvas_center) {
+                if let Some(hit) =
+                    self.hit_test_compound(response.interact_pointer_pos(), canvas_center)
+                {
                     // Begin dragging a node.
                     self.dragging = Some(hit);
                     self.selection = Some(hit);
@@ -63,7 +74,19 @@ impl SpaghettiApp {
             // Handle click (select) — only when not dragging.
             if response.clicked() {
                 if let Some(pointer) = response.interact_pointer_pos() {
-                    self.selection = self.hit_test(Some(pointer), canvas_center);
+                    self.selection = self.hit_test_compound(Some(pointer), canvas_center);
+                }
+            }
+
+            // Handle double-click: toggle expand/collapse on container nodes.
+            if response.double_clicked() {
+                if let Some(pointer) = response.interact_pointer_pos() {
+                    if let Some(hit) = self.hit_test_compound(Some(pointer), canvas_center) {
+                        if self.layout_state.is_container(hit) {
+                            self.layout_state.toggle_expand(hit);
+                            self.sync_hidden_symbols();
+                        }
+                    }
                 }
             }
 
@@ -114,18 +137,130 @@ impl SpaghettiApp {
             let draw_labels = !circle_mode && self.camera.zoom >= 0.4;
             let draw_rects = !circle_mode && self.camera.zoom >= 0.15;
 
-            // Draw edges (skip if both endpoints are outside the viewport)
+            // --- Build edge rerouting map for collapsed containers ---
+            let reroute = self.build_edge_reroute_map();
+
+            // --- 1. Draw expanded container backgrounds ---
+            // Store container screen rects for hit-testing.
+            self.container_rects.clear();
+            for (id, sym) in &self.graph.symbols {
+                if !self.layout_state.is_container(*id) || !self.layout_state.is_expanded(*id) {
+                    continue;
+                }
+                if self.hidden_symbols.contains(id) {
+                    continue;
+                }
+                let children = self.layout_state.children_of(*id);
+                if children.is_empty() {
+                    continue;
+                }
+
+                // Compute world-space bounding box of visible children.
+                let mut min_w = GVec2::splat(f32::INFINITY);
+                let mut max_w = GVec2::splat(f32::NEG_INFINITY);
+                let mut has_visible = false;
+                for &child_id in &children {
+                    if self.hidden_symbols.contains(&child_id) {
+                        continue;
+                    }
+                    if let Some(&pos) = self.positions.0.get(&child_id) {
+                        min_w = min_w.min(pos - GVec2::new(NODE_WIDTH / 2.0, NODE_HEIGHT / 2.0));
+                        max_w = max_w.max(pos + GVec2::new(NODE_WIDTH / 2.0, NODE_HEIGHT / 2.0));
+                        has_visible = true;
+                    }
+                }
+                if !has_visible {
+                    continue;
+                }
+
+                // Also include the container node itself in the bounds.
+                if let Some(&parent_pos) = self.positions.0.get(id) {
+                    min_w = min_w.min(parent_pos - GVec2::new(NODE_WIDTH / 2.0, NODE_HEIGHT / 2.0));
+                    max_w = max_w.max(parent_pos + GVec2::new(NODE_WIDTH / 2.0, NODE_HEIGHT / 2.0));
+                }
+
+                // Add padding and leave space for the title at the top.
+                let title_height = 20.0; // world units for the title bar
+                min_w -= GVec2::new(CONTAINER_PADDING, CONTAINER_PADDING + title_height);
+                max_w += GVec2::new(CONTAINER_PADDING, CONTAINER_PADDING);
+
+                // Viewport culling for the container.
+                if max_w.x < vis_min.x
+                    || min_w.x > vis_max.x
+                    || max_w.y < vis_min.y
+                    || min_w.y > vis_max.y
+                {
+                    continue;
+                }
+
+                let screen_min = self.camera.world_to_screen(min_w, canvas_center);
+                let screen_max = self.camera.world_to_screen(max_w, canvas_center);
+                let container_rect = Rect::from_min_max(screen_min, screen_max);
+
+                // Store for hit-testing.
+                self.container_rects.push((*id, container_rect));
+
+                // Draw background.
+                let base_color = self.render.node_color(sym.kind);
+                let bg = with_alpha(base_color, 0.15);
+                painter.rect_filled(container_rect, 8.0, bg);
+                painter.rect_stroke(
+                    container_rect,
+                    8.0,
+                    Stroke::new(1.0, with_alpha(base_color, 0.4)),
+                    StrokeKind::Outside,
+                );
+
+                // Draw container title at the top-left.
+                if draw_labels {
+                    let title_pos =
+                        egui::Pos2::new(container_rect.left() + 6.0, container_rect.top() + 2.0);
+                    let font = egui::FontId::proportional(13.0 * self.camera.zoom);
+                    painter.text(
+                        title_pos,
+                        egui::Align2::LEFT_TOP,
+                        &sym.name,
+                        font,
+                        with_alpha(Color32::WHITE, 0.8),
+                    );
+                }
+            }
+
+            // --- 2. Draw edges (with rerouting for collapsed containers) ---
+            let mut drawn_aggregated: HashSet<(SymbolId, SymbolId, u8)> = HashSet::new();
+
             for edge in &self.graph.edges {
                 if !active_kinds.contains(&edge.kind) {
                     continue;
                 }
-                if self.hidden_symbols.contains(&edge.from)
-                    || self.hidden_symbols.contains(&edge.to)
-                {
+
+                // Reroute endpoints through collapsed containers.
+                let from_id = reroute.get(&edge.from).copied().unwrap_or(edge.from);
+                let to_id = reroute.get(&edge.to).copied().unwrap_or(edge.to);
+
+                // Skip internal edges (both endpoints reroute to same container).
+                if from_id == to_id {
                     continue;
                 }
-                let from_pos = self.positions.0.get(&edge.from);
-                let to_pos = self.positions.0.get(&edge.to);
+
+                // Skip if either effective endpoint is hidden.
+                if self.hidden_symbols.contains(&from_id) || self.hidden_symbols.contains(&to_id) {
+                    continue;
+                }
+
+                // Dedup aggregated edges: if this is a rerouted edge, only draw
+                // one line per (from_container, to_container, kind) triple.
+                let is_rerouted =
+                    reroute.contains_key(&edge.from) || reroute.contains_key(&edge.to);
+                if is_rerouted {
+                    let kind_disc = edge.kind as u8;
+                    if !drawn_aggregated.insert((from_id, to_id, kind_disc)) {
+                        continue;
+                    }
+                }
+
+                let from_pos = self.positions.0.get(&from_id);
+                let to_pos = self.positions.0.get(&to_id);
                 if let (Some(&from), Some(&to)) = (from_pos, to_pos) {
                     // Cull: skip edge if both endpoints are outside the viewport.
                     let from_visible = from.x >= vis_min.x
@@ -145,15 +280,18 @@ impl SpaghettiApp {
 
                     let color =
                         with_alpha(self.render.edge_color(edge.kind), self.render.edge_opacity);
-                    painter.line_segment([screen_from, screen_to], Stroke::new(1.5, color));
+                    let thickness = if is_rerouted { 2.5 } else { 1.5 };
+                    painter.line_segment([screen_from, screen_to], Stroke::new(thickness, color));
                 }
             }
 
-            // Draw nodes
+            // --- 3. Draw nodes ---
             let node_size = Vec2::new(
                 NODE_WIDTH * self.camera.zoom,
                 NODE_HEIGHT * self.camera.zoom,
             );
+            let container_node_size = node_size * COLLAPSED_CONTAINER_SCALE;
+
             for (id, sym) in &self.graph.symbols {
                 if self.hidden_symbols.contains(id) {
                     continue;
@@ -172,8 +310,16 @@ impl SpaghettiApp {
                     let base =
                         with_alpha(self.render.node_color(sym.kind), self.render.node_opacity);
 
+                    let is_container = self.layout_state.is_container(*id);
+                    let is_collapsed = is_container && !self.layout_state.is_expanded(*id);
+
                     if draw_rects {
-                        let rect = Rect::from_center_size(screen_pos, node_size);
+                        let size = if is_collapsed {
+                            container_node_size
+                        } else {
+                            node_size
+                        };
+                        let rect = Rect::from_center_size(screen_pos, size);
 
                         let bg = if self.selection == Some(*id) {
                             brighten(base, 2.0)
@@ -181,20 +327,29 @@ impl SpaghettiApp {
                             base
                         };
                         painter.rect_filled(rect, 4.0, bg);
+
+                        // Collapsed containers get a thicker border.
+                        let border_width = if is_collapsed { 2.0 } else { 1.0 };
                         painter.rect_stroke(
                             rect,
                             4.0,
-                            Stroke::new(1.0, Color32::from_gray(60)),
+                            Stroke::new(border_width, Color32::from_gray(60)),
                             StrokeKind::Outside,
                         );
 
                         // Label (only when zoomed in enough)
                         if draw_labels {
                             let font = egui::FontId::proportional(12.0 * self.camera.zoom);
+                            let label = if is_collapsed {
+                                let n = self.layout_state.children_of(*id).len();
+                                format!("{} (+{})", sym.name, n)
+                            } else {
+                                sym.name.clone()
+                            };
                             painter.text(
                                 screen_pos,
                                 egui::Align2::CENTER_CENTER,
-                                &sym.name,
+                                &label,
                                 font,
                                 Color32::WHITE,
                             );
@@ -207,7 +362,12 @@ impl SpaghettiApp {
                             base
                         };
                         let r = if circle_mode {
-                            circle_radius * self.camera.zoom
+                            let base_r = circle_radius * self.camera.zoom;
+                            if is_collapsed {
+                                base_r * COLLAPSED_CONTAINER_SCALE
+                            } else {
+                                base_r
+                            }
                         } else {
                             2.0
                         };
@@ -220,6 +380,59 @@ impl SpaghettiApp {
             self.fps.tick();
             paint_fps_overlay(ui, response.rect, self.fps.fps());
         });
+    }
+
+    /// Build a map from child symbol ID -> collapsed parent symbol ID
+    /// for edge rerouting.
+    fn build_edge_reroute_map(&self) -> HashMap<SymbolId, SymbolId> {
+        let mut reroute = HashMap::new();
+        for (id, _sym) in &self.graph.symbols {
+            if self.layout_state.is_container(*id) && !self.layout_state.is_expanded(*id) {
+                for child_id in self.layout_state.children_of(*id) {
+                    reroute.insert(child_id, *id);
+                }
+            }
+        }
+        reroute
+    }
+
+    /// Hit-test that accounts for expanded container backgrounds.
+    ///
+    /// Checks children first (they're on top), then regular nodes,
+    /// then expanded container backgrounds.
+    fn hit_test_compound(
+        &self,
+        pointer: Option<egui::Pos2>,
+        canvas_center: egui::Pos2,
+    ) -> Option<SymbolId> {
+        // First try the normal node hit-test (children and regular nodes).
+        let radius = if self.render.circle_mode {
+            Some(self.render.circle_radius)
+        } else {
+            None
+        };
+        if let Some(hit) = crate::camera::hit_test(
+            &self.camera,
+            &self.positions,
+            pointer,
+            canvas_center,
+            radius,
+        ) {
+            // Only return if the node is visible (not hidden by collapse/file-tree).
+            if !self.hidden_symbols.contains(&hit) {
+                return Some(hit);
+            }
+        }
+
+        // Then check expanded container background rects.
+        let pointer = pointer?;
+        for &(id, rect) in self.container_rects.iter().rev() {
+            if rect.contains(pointer) {
+                return Some(id);
+            }
+        }
+
+        None
     }
 }
 

--- a/crates/viz/src/panels/left.rs
+++ b/crates/viz/src/panels/left.rs
@@ -81,10 +81,22 @@ impl SpaghettiApp {
 
                 // If visibility changed, recompute hidden set and push to layout.
                 if visibility_changed {
-                    self.hidden_symbols = self.file_tree.hidden_symbols();
-                    let hidden_vec: Vec<_> = self.hidden_symbols.iter().copied().collect();
-                    self.layout_state.set_hidden(&hidden_vec);
+                    self.sync_hidden_symbols();
                 }
+
+                ui.separator();
+
+                // Collapse / Expand All buttons
+                ui.horizontal(|ui| {
+                    if ui.button("Collapse All").clicked() {
+                        self.layout_state.collapse_all();
+                        self.sync_hidden_symbols();
+                    }
+                    if ui.button("Expand All").clicked() {
+                        self.layout_state.expand_all();
+                        self.sync_hidden_symbols();
+                    }
+                });
             });
     }
 }

--- a/crates/viz/src/panels/right.rs
+++ b/crates/viz/src/panels/right.rs
@@ -34,6 +34,26 @@ impl SpaghettiApp {
                                 ui.label(format!("Attrs: {:?}", sym.attrs));
                             }
 
+                            // Collapse/Expand button for container nodes.
+                            if self.layout_state.is_container(sel_id) {
+                                ui.separator();
+                                let children = self.layout_state.children_of(sel_id);
+                                let n = children.len();
+                                if self.layout_state.is_expanded(sel_id) {
+                                    ui.label(format!("Children: {n} (expanded)"));
+                                    if ui.button("Collapse").clicked() {
+                                        self.layout_state.collapse(sel_id);
+                                        self.sync_hidden_symbols();
+                                    }
+                                } else {
+                                    ui.label(format!("Children: {n} (collapsed)"));
+                                    if ui.button("Expand").clicked() {
+                                        self.layout_state.expand(sel_id);
+                                        self.sync_hidden_symbols();
+                                    }
+                                }
+                            }
+
                             // -- Edge summary by type --
                             ui.separator();
                             ui.heading("Connections");
@@ -248,6 +268,17 @@ impl SpaghettiApp {
                             }
                         });
                     }
+
+                    ui.add_space(8.0);
+                    ui.label("Containment");
+
+                    let params = self.layout_state.params_mut();
+                    changed |= ui
+                        .add(
+                            egui::Slider::new(&mut params.containment_strength, 0.0..=0.2)
+                                .text("Strength"),
+                        )
+                        .changed();
 
                     ui.add_space(8.0);
                     ui.label("Location Affinity");


### PR DESCRIPTION
## Summary
This PR adds support for collapsing and expanding container nodes (nodes with Contains edges to children) in the graph visualization. When collapsed, a container shows a count of hidden children and visually represents them as a single larger node. When expanded, children are displayed with a grouped background and edges are rerouted through the container for cleaner visualization.

## Key Changes

### Layout State Management (`crates/layout/src/lib.rs`)
- Added containment hierarchy tracking: `parent_of`, `children_of`, and `containers` fields to track Contains relationships
- Added `expanded` set to track which containers are currently expanded (default: all collapsed)
- Separated collapse-hidden state from external (file-tree) hidden state with `collapse_hidden` and `external_hidden` fields
- Implemented `collapse()`, `expand()`, `toggle_expand()`, and related query methods (`is_container()`, `is_expanded()`, `children_of()`, `parent_of()`)
- Added `collapse_all()` and `expand_all()` convenience methods
- Implemented containment force in force simulation: pulls children of expanded containers toward their siblings' centroid to keep them clustered
- Added `containment_strength` parameter (default 0.02) to control the strength of this force

### Canvas Rendering (`crates/viz/src/panels/canvas.rs`)
- Added `hit_test_compound()` method that checks both regular nodes and expanded container backgrounds for hit-testing
- Implemented edge rerouting: edges from/to children of collapsed containers are rerouted to the container itself, with deduplication to avoid drawing multiple edges between the same container pair
- Added rendering of expanded container backgrounds with semi-transparent colored rectangles and title labels
- Scaled collapsed container nodes 1.3× larger and added child count to their labels (e.g., "Container (+5)")
- Made rerouted edges thicker (2.5 vs 1.5) for visual distinction
- Added double-click handler to toggle container expand/collapse
- Store container screen rects each frame for hit-testing against backgrounds

### UI Controls
- Added "Collapse All" / "Expand All" buttons in the left panel (file tree area)
- Added collapse/expand buttons in the right panel (properties) for selected container nodes
- Added `containment_strength` slider in the layout parameters panel
- Integrated collapse state with file-tree visibility: `sync_hidden_symbols()` merges both sources

### App State (`crates/viz/src/app.rs`)
- Added `container_rects` field to cache screen-space rectangles of expanded containers for hit-testing
- Implemented `sync_hidden_symbols()` to merge file-tree and collapse visibility states
- Removed the old `hit_test()` method (now in camera module)

## Implementation Details
- Containers default to collapsed on load, with children hidden and positioned at the parent's location
- On expand, children are scattered in a circle around the parent for animation
- The containment force keeps expanded children clustered together during simulation
- Edge rerouting is transparent to the user: internal edges (both endpoints in same collapsed container) are skipped
- Container backgrounds are drawn before nodes so they appear behind, with proper viewport culling
- Hit-testing prioritizes visible nodes first, then checks container backgrounds for selection

https://claude.ai/code/session_01Re7LvAPFt8oDwzas8xX1Er