### PR TITLE
Claude/implement issue 33 y7 rq8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,15 @@ examples/
 ## Running
 
 ```bash
-# Requires libclang
+# Requires libclang. First run: pass a compile_commands.json path.
 LIBCLANG_PATH=$(brew --prefix llvm)/lib cargo run -p viz -- examples/tiny-cpp/compile_commands.json
+
+# Subsequent runs: the last-opened project is restored from
+# `spaghetti_settings.json`, so no CLI argument is needed.
+LIBCLANG_PATH=$(brew --prefix llvm)/lib cargo run -p viz
 ```
 
-Expected result: a window showing classes (Shape, Circle, Square), methods, fields, and `main` with inheritance, call, contains, overrides, and field-access edges. The force-directed layout animates into place over ~1-2 seconds. A file-tree panel on the left allows filtering by directory; a details panel on the right shows selected symbol info.
+Expected result (for `examples/tiny-cpp`): a window showing classes (Shape, Circle, Square), methods, fields, and `main` with inheritance, call, contains, overrides, and field-access edges. The force-directed layout animates into place over ~1-2 seconds. A file-tree panel on the left allows filtering by directory; a details panel on the right shows selected symbol info.
 
 ## libclang Setup
 
@@ -150,7 +154,7 @@ To verify the project is healthy:
 LIBCLANG_PATH=$(brew --prefix llvm)/lib cargo check --workspace && cargo test --workspace && cargo run -p viz -- examples/tiny-cpp/compile_commands.json
 ```
 
-All three should succeed and a window should appear showing the indexed graph with animated layout.
+All three should succeed and a window should appear showing the indexed graph with animated layout. If a project is already saved in `spaghetti_settings.json`, the CLI argument is optional — it is only needed to switch projects or on a fresh install.
 
 ## Handoff Rule
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ On macOS you also need: `export LIBCLANG_PATH=$(brew --prefix llvm)/lib`
 
 This is idempotent and fast if libclang is already present. **Cloud / CI agents must run this before any cargo command.**
 
+On macOS the viz crate's `build.rs` bakes `$LIBCLANG_PATH` into the
+binary as an `LC_RPATH` entry, so you do **not** need to set
+`DYLD_FALLBACK_LIBRARY_PATH` at runtime — the release binary finds
+`libclang.dylib` on its own.
+
 ## Architecture
 
 ```

--- a/crates/layout/src/forces/container_repulsion.rs
+++ b/crates/layout/src/forces/container_repulsion.rs
@@ -7,10 +7,9 @@
 //! stays laid out relative to itself while the whole block slides.
 //!
 //! Containers are grouped by their shared parent (sibling groups) so
-//! unrelated containers at different tree levels can't repel each other,
-//! only direct siblings can. A grid indexed by maximum container extent
-//! keeps the per-group comparison to a 3×3 neighbourhood instead of
-//! `O(S²)` pairs.
+//! only direct siblings can repel each other. A grid indexed by the
+//! maximum container extent keeps per-group comparison to a 3×3
+//! neighbourhood instead of `O(S²)` pairs.
 
 use glam::Vec2;
 use std::any::Any;
@@ -22,13 +21,12 @@ use super::{Force, ForceContext};
 pub struct ContainerRepulsion {
     /// Whether this force is currently active.
     pub enabled: bool,
-    /// Overlap-depth coefficient. The force pushing each pair apart scales
-    /// linearly with `strength * overlap`.
+    /// Overlap-depth coefficient. The per-pair force scales linearly as
+    /// `strength * overlap`.
     pub strength: f32,
     /// Sibling groups: containers grouped by their shared parent.
-    /// `sibling_groups[i]` is a list of container indices whose direct
-    /// parent is the same. Top-level containers form a single group.
-    pub sibling_groups: Vec<Vec<usize>>,
+    /// Top-level containers form a single group.
+    sibling_groups: Vec<Vec<usize>>,
 }
 
 impl ContainerRepulsion {
@@ -44,10 +42,6 @@ impl ContainerRepulsion {
 }
 
 impl Force for ContainerRepulsion {
-    fn name(&self) -> &str {
-        "container_repulsion"
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -63,7 +57,6 @@ impl Force for ContainerRepulsion {
         let cr = self.strength;
 
         for group in &self.sibling_groups {
-            // Collect the expanded, visible containers in this group.
             let live_siblings: Vec<usize> = group
                 .iter()
                 .copied()
@@ -73,14 +66,12 @@ impl Force for ContainerRepulsion {
                 continue;
             }
 
-            // Grid-accelerated overlap detection: bucket containers by cell
-            // so we only check nearby pairs instead of all O(S²).
+            // Cell size = largest container extent so overlapping pairs
+            // are always in the same or adjacent cells.
             let max_extent = live_siblings
                 .iter()
                 .map(|&c| ctx.sizes[c].x.max(ctx.sizes[c].y))
                 .fold(0.0f32, f32::max);
-            // Cell size = largest container extent so overlapping pairs are
-            // always in the same or adjacent cells.
             let cell_size = max_extent.max(1.0);
             let inv_cell = 1.0 / cell_size;
 
@@ -91,7 +82,6 @@ impl Force for ContainerRepulsion {
                 grid.entry((cx, cy)).or_default().push(c);
             }
 
-            // Check each container against neighbours in a 3×3 cell window.
             for &a in &live_siblings {
                 let pos_a = ctx.positions[a];
                 let half_a = ctx.sizes[a] * 0.5;
@@ -105,19 +95,18 @@ impl Force for ContainerRepulsion {
                             continue;
                         };
                         for &b in bucket {
-                            // Avoid self-pairs and double-counting (a < b).
+                            // Avoid self-pairs and double-counting.
                             if b <= a {
                                 continue;
                             }
                             let pos_b = ctx.positions[b];
                             let half_b = ctx.sizes[b] * 0.5;
 
-                            // AABB overlap test on each axis.
                             let overlap_x = (half_a.x + half_b.x) - (pos_a.x - pos_b.x).abs();
                             let overlap_y = (half_a.y + half_b.y) - (pos_a.y - pos_b.y).abs();
 
                             if overlap_x <= 0.0 || overlap_y <= 0.0 {
-                                continue; // No overlap — skip.
+                                continue;
                             }
 
                             // Push apart along the axis of least overlap
@@ -129,7 +118,6 @@ impl Force for ContainerRepulsion {
                                 Vec2::new(0.0, delta.y.signum() * overlap_y * cr)
                             };
 
-                            // Rigid-body: move container + all descendants.
                             apply_force_to_subtree(a, f, forces, ctx.children_of, ctx.active);
                             apply_force_to_subtree(b, -f, forces, ctx.children_of, ctx.active);
                         }
@@ -149,8 +137,7 @@ impl Force for ContainerRepulsion {
 }
 
 /// Apply a force to a node and all its descendants (rigid-body
-/// translation). Walks the subtree via `children_of` without allocating.
-/// Descendants whose `active` flag is `false` are skipped.
+/// translation). Descendants whose `active` flag is `false` are skipped.
 fn apply_force_to_subtree(
     root: usize,
     force: Vec2,
@@ -159,7 +146,6 @@ fn apply_force_to_subtree(
     active: &[bool],
 ) {
     forces[root] += force;
-    // Use a manual stack to avoid recursion overhead.
     let mut stack: Vec<usize> = children_of[root].clone();
     while let Some(node) = stack.pop() {
         if active[node] {
@@ -172,136 +158,51 @@ fn apply_force_to_subtree(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core_ir::EdgeKind;
-    use std::collections::HashSet;
-
-    fn mk_ctx<'a>(
-        positions: &'a [Vec2],
-        active: &'a [bool],
-        sizes: &'a [Vec2],
-        children_of: &'a [Vec<usize>],
-        containers: &'a HashSet<usize>,
-        expanded: &'a HashSet<usize>,
-        toplevel: &'a HashSet<usize>,
-        degrees: &'a [f32],
-        edge_pairs: &'a [(usize, usize, EdgeKind)],
-        visible_edge_kinds: &'a [EdgeKind],
-    ) -> ForceContext<'a> {
-        ForceContext {
-            positions,
-            sizes,
-            degrees,
-            active,
-            edge_pairs,
-            visible_edge_kinds,
-            children_of,
-            containers,
-            expanded,
-            toplevel_containers: toplevel,
-            node_count: positions.len(),
-        }
-    }
+    use crate::forces::test_utils::TestCtx;
 
     #[test]
     fn non_overlapping_siblings_unaffected() {
         // Two sibling containers 100 apart with half-size 10 — no overlap.
-        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::new(20.0, 20.0); 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::from([0, 1]);
-        let expanded = HashSet::from([0, 1]);
-        let toplevel = HashSet::new();
-        let degrees = vec![1.0; 2];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        let mut tc = TestCtx::new(vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)]);
+        tc.sizes = vec![Vec2::new(20.0, 20.0); 2];
+        tc.containers.insert(0);
+        tc.containers.insert(1);
+        tc.expanded.insert(0);
+        tc.expanded.insert(1);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        let sibling_groups = vec![vec![0, 1]];
-        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
+        ContainerRepulsion::new(1.0, vec![vec![0, 1]], true).apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
     #[test]
     fn overlapping_siblings_pushed_apart() {
         // Two expanded containers overlapping along the x axis.
-        // a at -5, b at +5, each 20 wide → centres 10 apart, extents
-        // touch across the full overlap zone.
-        let positions = vec![Vec2::new(-5.0, 0.0), Vec2::new(5.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::new(20.0, 20.0); 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::from([0, 1]);
-        let expanded = HashSet::from([0, 1]);
-        let toplevel = HashSet::new();
-        let degrees = vec![1.0; 2];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        let mut tc = TestCtx::new(vec![Vec2::new(-5.0, 0.0), Vec2::new(5.0, 0.0)]);
+        tc.sizes = vec![Vec2::new(20.0, 20.0); 2];
+        tc.containers.insert(0);
+        tc.containers.insert(1);
+        tc.expanded.insert(0);
+        tc.expanded.insert(1);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        let sibling_groups = vec![vec![0, 1]];
-        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
-        // Container a (at -x) pushed in -x, b (at +x) pushed in +x.
+        ContainerRepulsion::new(1.0, vec![vec![0, 1]], true).apply(&tc.view(), &mut forces);
+
         assert!(forces[0].x < 0.0);
         assert!(forces[1].x > 0.0);
-        // Newton's third law.
         assert!((forces[0] + forces[1]).length() < 1e-4);
     }
 
     #[test]
     fn collapsed_siblings_do_not_participate() {
-        // Same overlapping setup as the previous test, but neither
-        // container is expanded — force should be a no-op.
-        let positions = vec![Vec2::new(-5.0, 0.0), Vec2::new(5.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::new(20.0, 20.0); 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::from([0, 1]);
-        let expanded = HashSet::new(); // nothing expanded
-        let toplevel = HashSet::new();
-        let degrees = vec![1.0; 2];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        // Same overlapping setup, but neither container is expanded.
+        let mut tc = TestCtx::new(vec![Vec2::new(-5.0, 0.0), Vec2::new(5.0, 0.0)]);
+        tc.sizes = vec![Vec2::new(20.0, 20.0); 2];
+        tc.containers.insert(0);
+        tc.containers.insert(1);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        let sibling_groups = vec![vec![0, 1]];
-        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
+        ContainerRepulsion::new(1.0, vec![vec![0, 1]], true).apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
@@ -309,42 +210,26 @@ mod tests {
     fn force_applied_to_container_and_descendants() {
         // Container 0 has child 2; container 1 has child 3. Overlapping
         // siblings should have their subtrees translated rigidly.
-        let positions = vec![
+        let mut tc = TestCtx::new(vec![
             Vec2::new(-5.0, 0.0),
             Vec2::new(5.0, 0.0),
             Vec2::new(-5.0, 0.0),
             Vec2::new(5.0, 0.0),
-        ];
-        let active = vec![true; 4];
-        let sizes = vec![Vec2::new(20.0, 20.0); 4];
-        let children_of: Vec<Vec<usize>> = vec![vec![2], vec![3], vec![], vec![]];
-        let containers = HashSet::from([0, 1]);
-        let expanded = HashSet::from([0, 1]);
-        let toplevel = HashSet::new();
-        let degrees = vec![1.0; 4];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        ]);
+        tc.sizes = vec![Vec2::new(20.0, 20.0); 4];
+        tc.children_of[0] = vec![2];
+        tc.children_of[1] = vec![3];
+        tc.containers.insert(0);
+        tc.containers.insert(1);
+        tc.expanded.insert(0);
+        tc.expanded.insert(1);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 4];
-        let sibling_groups = vec![vec![0, 1]];
-        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
+        ContainerRepulsion::new(1.0, vec![vec![0, 1]], true).apply(&tc.view(), &mut forces);
 
         // Container and its child get identical force vectors (rigid body).
         assert_eq!(forces[0], forces[2]);
         assert_eq!(forces[1], forces[3]);
-        // And the two subtrees get opposite pushes.
         assert!(forces[0].x < 0.0);
         assert!(forces[1].x > 0.0);
     }

--- a/crates/layout/src/forces/container_repulsion.rs
+++ b/crates/layout/src/forces/container_repulsion.rs
@@ -1,0 +1,351 @@
+//! Container-overlap resolution force.
+//!
+//! Sibling containers that currently overlap get pushed apart along the
+//! axis of least penetration, with force proportional to the overlap
+//! depth. The push is applied as a rigid-body translation of each
+//! container plus all of its descendants, so the inside of a container
+//! stays laid out relative to itself while the whole block slides.
+//!
+//! Containers are grouped by their shared parent (sibling groups) so
+//! unrelated containers at different tree levels can't repel each other,
+//! only direct siblings can. A grid indexed by maximum container extent
+//! keeps the per-group comparison to a 3×3 neighbourhood instead of
+//! `O(S²)` pairs.
+
+use glam::Vec2;
+use std::any::Any;
+use std::collections::HashMap;
+
+use super::{Force, ForceContext};
+
+/// Sibling-container AABB overlap resolution.
+pub struct ContainerRepulsion {
+    /// Whether this force is currently active.
+    pub enabled: bool,
+    /// Overlap-depth coefficient. The force pushing each pair apart scales
+    /// linearly with `strength * overlap`.
+    pub strength: f32,
+    /// Sibling groups: containers grouped by their shared parent.
+    /// `sibling_groups[i]` is a list of container indices whose direct
+    /// parent is the same. Top-level containers form a single group.
+    pub sibling_groups: Vec<Vec<usize>>,
+}
+
+impl ContainerRepulsion {
+    /// Create a new container-repulsion force with precomputed sibling
+    /// groups.
+    pub fn new(strength: f32, sibling_groups: Vec<Vec<usize>>, enabled: bool) -> Self {
+        Self {
+            enabled,
+            strength,
+            sibling_groups,
+        }
+    }
+}
+
+impl Force for ContainerRepulsion {
+    fn name(&self) -> &str {
+        "container_repulsion"
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
+        if self.strength <= 0.0 {
+            return;
+        }
+        let cr = self.strength;
+
+        for group in &self.sibling_groups {
+            // Collect the expanded, visible containers in this group.
+            let live_siblings: Vec<usize> = group
+                .iter()
+                .copied()
+                .filter(|&c| ctx.active[c] && ctx.expanded.contains(&c))
+                .collect();
+            if live_siblings.len() < 2 {
+                continue;
+            }
+
+            // Grid-accelerated overlap detection: bucket containers by cell
+            // so we only check nearby pairs instead of all O(S²).
+            let max_extent = live_siblings
+                .iter()
+                .map(|&c| ctx.sizes[c].x.max(ctx.sizes[c].y))
+                .fold(0.0f32, f32::max);
+            // Cell size = largest container extent so overlapping pairs are
+            // always in the same or adjacent cells.
+            let cell_size = max_extent.max(1.0);
+            let inv_cell = 1.0 / cell_size;
+
+            let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
+            for &c in &live_siblings {
+                let cx = (ctx.positions[c].x * inv_cell).floor() as i32;
+                let cy = (ctx.positions[c].y * inv_cell).floor() as i32;
+                grid.entry((cx, cy)).or_default().push(c);
+            }
+
+            // Check each container against neighbours in a 3×3 cell window.
+            for &a in &live_siblings {
+                let pos_a = ctx.positions[a];
+                let half_a = ctx.sizes[a] * 0.5;
+                let ax = (pos_a.x * inv_cell).floor() as i32;
+                let ay = (pos_a.y * inv_cell).floor() as i32;
+
+                for dx in -1i32..=1 {
+                    for dy in -1i32..=1 {
+                        let key = (ax.wrapping_add(dx), ay.wrapping_add(dy));
+                        let Some(bucket) = grid.get(&key) else {
+                            continue;
+                        };
+                        for &b in bucket {
+                            // Avoid self-pairs and double-counting (a < b).
+                            if b <= a {
+                                continue;
+                            }
+                            let pos_b = ctx.positions[b];
+                            let half_b = ctx.sizes[b] * 0.5;
+
+                            // AABB overlap test on each axis.
+                            let overlap_x = (half_a.x + half_b.x) - (pos_a.x - pos_b.x).abs();
+                            let overlap_y = (half_a.y + half_b.y) - (pos_a.y - pos_b.y).abs();
+
+                            if overlap_x <= 0.0 || overlap_y <= 0.0 {
+                                continue; // No overlap — skip.
+                            }
+
+                            // Push apart along the axis of least overlap
+                            // (minimum penetration direction).
+                            let delta = pos_a - pos_b;
+                            let f = if overlap_x < overlap_y {
+                                Vec2::new(delta.x.signum() * overlap_x * cr, 0.0)
+                            } else {
+                                Vec2::new(0.0, delta.y.signum() * overlap_y * cr)
+                            };
+
+                            // Rigid-body: move container + all descendants.
+                            apply_force_to_subtree(a, f, forces, ctx.children_of, ctx.active);
+                            apply_force_to_subtree(b, -f, forces, ctx.children_of, ctx.active);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Apply a force to a node and all its descendants (rigid-body
+/// translation). Walks the subtree via `children_of` without allocating.
+/// Descendants whose `active` flag is `false` are skipped.
+fn apply_force_to_subtree(
+    root: usize,
+    force: Vec2,
+    forces: &mut [Vec2],
+    children_of: &[Vec<usize>],
+    active: &[bool],
+) {
+    forces[root] += force;
+    // Use a manual stack to avoid recursion overhead.
+    let mut stack: Vec<usize> = children_of[root].clone();
+    while let Some(node) = stack.pop() {
+        if active[node] {
+            forces[node] += force;
+            stack.extend_from_slice(&children_of[node]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_ir::EdgeKind;
+    use std::collections::HashSet;
+
+    fn mk_ctx<'a>(
+        positions: &'a [Vec2],
+        active: &'a [bool],
+        sizes: &'a [Vec2],
+        children_of: &'a [Vec<usize>],
+        containers: &'a HashSet<usize>,
+        expanded: &'a HashSet<usize>,
+        toplevel: &'a HashSet<usize>,
+        degrees: &'a [f32],
+        edge_pairs: &'a [(usize, usize, EdgeKind)],
+        visible_edge_kinds: &'a [EdgeKind],
+    ) -> ForceContext<'a> {
+        ForceContext {
+            positions,
+            sizes,
+            degrees,
+            active,
+            edge_pairs,
+            visible_edge_kinds,
+            children_of,
+            containers,
+            expanded,
+            toplevel_containers: toplevel,
+            node_count: positions.len(),
+        }
+    }
+
+    #[test]
+    fn non_overlapping_siblings_unaffected() {
+        // Two sibling containers 100 apart with half-size 10 — no overlap.
+        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::new(20.0, 20.0); 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::from([0, 1]);
+        let expanded = HashSet::from([0, 1]);
+        let toplevel = HashSet::new();
+        let degrees = vec![1.0; 2];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        let sibling_groups = vec![vec![0, 1]];
+        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn overlapping_siblings_pushed_apart() {
+        // Two expanded containers overlapping along the x axis.
+        // a at -5, b at +5, each 20 wide → centres 10 apart, extents
+        // touch across the full overlap zone.
+        let positions = vec![Vec2::new(-5.0, 0.0), Vec2::new(5.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::new(20.0, 20.0); 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::from([0, 1]);
+        let expanded = HashSet::from([0, 1]);
+        let toplevel = HashSet::new();
+        let degrees = vec![1.0; 2];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        let sibling_groups = vec![vec![0, 1]];
+        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
+        // Container a (at -x) pushed in -x, b (at +x) pushed in +x.
+        assert!(forces[0].x < 0.0);
+        assert!(forces[1].x > 0.0);
+        // Newton's third law.
+        assert!((forces[0] + forces[1]).length() < 1e-4);
+    }
+
+    #[test]
+    fn collapsed_siblings_do_not_participate() {
+        // Same overlapping setup as the previous test, but neither
+        // container is expanded — force should be a no-op.
+        let positions = vec![Vec2::new(-5.0, 0.0), Vec2::new(5.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::new(20.0, 20.0); 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::from([0, 1]);
+        let expanded = HashSet::new(); // nothing expanded
+        let toplevel = HashSet::new();
+        let degrees = vec![1.0; 2];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        let sibling_groups = vec![vec![0, 1]];
+        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn force_applied_to_container_and_descendants() {
+        // Container 0 has child 2; container 1 has child 3. Overlapping
+        // siblings should have their subtrees translated rigidly.
+        let positions = vec![
+            Vec2::new(-5.0, 0.0),
+            Vec2::new(5.0, 0.0),
+            Vec2::new(-5.0, 0.0),
+            Vec2::new(5.0, 0.0),
+        ];
+        let active = vec![true; 4];
+        let sizes = vec![Vec2::new(20.0, 20.0); 4];
+        let children_of: Vec<Vec<usize>> = vec![vec![2], vec![3], vec![], vec![]];
+        let containers = HashSet::from([0, 1]);
+        let expanded = HashSet::from([0, 1]);
+        let toplevel = HashSet::new();
+        let degrees = vec![1.0; 4];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 4];
+        let sibling_groups = vec![vec![0, 1]];
+        ContainerRepulsion::new(1.0, sibling_groups, true).apply(&ctx, &mut forces);
+
+        // Container and its child get identical force vectors (rigid body).
+        assert_eq!(forces[0], forces[2]);
+        assert_eq!(forces[1], forces[3]);
+        // And the two subtrees get opposite pushes.
+        assert!(forces[0].x < 0.0);
+        assert!(forces[1].x > 0.0);
+    }
+}

--- a/crates/layout/src/forces/container_repulsion.rs
+++ b/crates/layout/src/forces/container_repulsion.rs
@@ -7,14 +7,16 @@
 //! stays laid out relative to itself while the whole block slides.
 //!
 //! Containers are grouped by their shared parent (sibling groups) so
-//! only direct siblings can repel each other. A grid indexed by the
-//! maximum container extent keeps per-group comparison to a 3×3
+//! only direct siblings can repel each other. A [`SpatialGrid`] indexed
+//! by the maximum container extent keeps per-group comparison to a 3×3
 //! neighbourhood instead of `O(S²)` pairs.
+//!
+//! [`SpatialGrid`]: super::grid::SpatialGrid
 
 use glam::Vec2;
 use std::any::Any;
-use std::collections::HashMap;
 
+use super::grid::SpatialGrid;
 use super::{Force, ForceContext};
 
 /// Sibling-container AABB overlap resolution.
@@ -73,56 +75,43 @@ impl Force for ContainerRepulsion {
                 .map(|&c| ctx.sizes[c].x.max(ctx.sizes[c].y))
                 .fold(0.0f32, f32::max);
             let cell_size = max_extent.max(1.0);
-            let inv_cell = 1.0 / cell_size;
-
-            let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
-            for &c in &live_siblings {
-                let cx = (ctx.positions[c].x * inv_cell).floor() as i32;
-                let cy = (ctx.positions[c].y * inv_cell).floor() as i32;
-                grid.entry((cx, cy)).or_default().push(c);
-            }
+            let grid = SpatialGrid::build(
+                cell_size,
+                live_siblings.iter().map(|&i| (i, ctx.positions[i])),
+            );
 
             for &a in &live_siblings {
                 let pos_a = ctx.positions[a];
                 let half_a = ctx.sizes[a] * 0.5;
-                let ax = (pos_a.x * inv_cell).floor() as i32;
-                let ay = (pos_a.y * inv_cell).floor() as i32;
+                let query_cell = grid.cell_of(pos_a);
 
-                for dx in -1i32..=1 {
-                    for dy in -1i32..=1 {
-                        let key = (ax.wrapping_add(dx), ay.wrapping_add(dy));
-                        let Some(bucket) = grid.get(&key) else {
-                            continue;
-                        };
-                        for &b in bucket {
-                            // Avoid self-pairs and double-counting.
-                            if b <= a {
-                                continue;
-                            }
-                            let pos_b = ctx.positions[b];
-                            let half_b = ctx.sizes[b] * 0.5;
-
-                            let overlap_x = (half_a.x + half_b.x) - (pos_a.x - pos_b.x).abs();
-                            let overlap_y = (half_a.y + half_b.y) - (pos_a.y - pos_b.y).abs();
-
-                            if overlap_x <= 0.0 || overlap_y <= 0.0 {
-                                continue;
-                            }
-
-                            // Push apart along the axis of least overlap
-                            // (minimum penetration direction).
-                            let delta = pos_a - pos_b;
-                            let f = if overlap_x < overlap_y {
-                                Vec2::new(delta.x.signum() * overlap_x * cr, 0.0)
-                            } else {
-                                Vec2::new(0.0, delta.y.signum() * overlap_y * cr)
-                            };
-
-                            apply_force_to_subtree(a, f, forces, ctx.children_of, ctx.active);
-                            apply_force_to_subtree(b, -f, forces, ctx.children_of, ctx.active);
-                        }
+                grid.for_each_in_neighborhood(query_cell, |b| {
+                    // Avoid self-pairs and double-counting.
+                    if b <= a {
+                        return;
                     }
-                }
+                    let pos_b = ctx.positions[b];
+                    let half_b = ctx.sizes[b] * 0.5;
+
+                    let overlap_x = (half_a.x + half_b.x) - (pos_a.x - pos_b.x).abs();
+                    let overlap_y = (half_a.y + half_b.y) - (pos_a.y - pos_b.y).abs();
+
+                    if overlap_x <= 0.0 || overlap_y <= 0.0 {
+                        return;
+                    }
+
+                    // Push apart along the axis of least overlap
+                    // (minimum penetration direction).
+                    let delta = pos_a - pos_b;
+                    let f = if overlap_x < overlap_y {
+                        Vec2::new(delta.x.signum() * overlap_x * cr, 0.0)
+                    } else {
+                        Vec2::new(0.0, delta.y.signum() * overlap_y * cr)
+                    };
+
+                    apply_force_to_subtree(a, f, forces, ctx.children_of, ctx.active);
+                    apply_force_to_subtree(b, -f, forces, ctx.children_of, ctx.active);
+                });
             }
         }
     }

--- a/crates/layout/src/forces/containment.rs
+++ b/crates/layout/src/forces/containment.rs
@@ -2,7 +2,7 @@
 //! their shared centroid.
 //!
 //! Each non-hidden container with at least two visible children computes
-//! the centroid of those children and pulls every child toward it by
+//! the centroid of those children and pulls each child toward it by
 //! `strength * (centroid - position)`. Top-level containers (namespaces,
 //! translation units) use half strength so class-level containment wins
 //! the tug-of-war.
@@ -29,10 +29,6 @@ impl Containment {
 }
 
 impl Force for Containment {
-    fn name(&self) -> &str {
-        "containment"
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -92,102 +88,35 @@ impl Force for Containment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core_ir::EdgeKind;
-    use std::collections::HashSet;
-
-    fn mk_ctx<'a>(
-        positions: &'a [Vec2],
-        active: &'a [bool],
-        children_of: &'a [Vec<usize>],
-        containers: &'a HashSet<usize>,
-        expanded: &'a HashSet<usize>,
-        toplevel: &'a HashSet<usize>,
-        sizes: &'a [Vec2],
-        degrees: &'a [f32],
-        edge_pairs: &'a [(usize, usize, EdgeKind)],
-        visible_edge_kinds: &'a [EdgeKind],
-    ) -> ForceContext<'a> {
-        ForceContext {
-            positions,
-            sizes,
-            degrees,
-            active,
-            edge_pairs,
-            visible_edge_kinds,
-            children_of,
-            containers,
-            expanded,
-            toplevel_containers: toplevel,
-            node_count: positions.len(),
-        }
-    }
+    use crate::forces::test_utils::TestCtx;
 
     #[test]
     fn singleton_child_receives_no_force() {
-        // Container 0 with a single child 1 — needs two visible children
-        // to do anything.
-        let positions = vec![Vec2::ZERO, Vec2::new(10.0, 0.0)];
-        let active = vec![true, true];
-        let children_of: Vec<Vec<usize>> = vec![vec![1], vec![]];
-        let mut containers = HashSet::new();
-        containers.insert(0);
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        // Container 0 with a single child 1 needs at least two visible
+        // children to produce any force.
+        let mut tc = TestCtx::new(vec![Vec2::ZERO, Vec2::new(10.0, 0.0)]);
+        tc.children_of[0] = vec![1];
+        tc.containers.insert(0);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        Containment::new(1.0, true).apply(&ctx, &mut forces);
+        Containment::new(1.0, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
     #[test]
     fn two_children_pulled_to_their_centroid() {
         // Container 0 contains children 1 and 2 symmetric around origin.
-        let positions = vec![
-            Vec2::new(100.0, 100.0), // container (unused by children pull)
+        let mut tc = TestCtx::new(vec![
+            Vec2::new(100.0, 100.0),
             Vec2::new(10.0, 0.0),
             Vec2::new(-10.0, 0.0),
-        ];
-        let active = vec![true, true, true];
-        let children_of: Vec<Vec<usize>> = vec![vec![1, 2], vec![], vec![]];
-        let mut containers = HashSet::new();
-        containers.insert(0);
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let sizes = vec![Vec2::ZERO; 3];
-        let degrees = vec![1.0; 3];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        ]);
+        tc.children_of[0] = vec![1, 2];
+        tc.containers.insert(0);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 3];
-        Containment::new(1.0, true).apply(&ctx, &mut forces);
+        Containment::new(1.0, true).apply(&tc.view(), &mut forces);
+
         // Centroid of children = origin. Each child pulled toward origin
         // by 1.0 * displacement.
         assert_eq!(forces[0], Vec2::ZERO);
@@ -197,33 +126,17 @@ mod tests {
 
     #[test]
     fn toplevel_container_uses_half_strength() {
-        let positions = vec![Vec2::ZERO, Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
-        let active = vec![true, true, true];
-        let children_of: Vec<Vec<usize>> = vec![vec![1, 2], vec![], vec![]];
-        let mut containers = HashSet::new();
-        containers.insert(0);
-        let expanded = HashSet::new();
-        let mut toplevel = HashSet::new();
-        toplevel.insert(0);
-        let sizes = vec![Vec2::ZERO; 3];
-        let degrees = vec![1.0; 3];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        let mut tc = TestCtx::new(vec![
+            Vec2::ZERO,
+            Vec2::new(10.0, 0.0),
+            Vec2::new(-10.0, 0.0),
+        ]);
+        tc.children_of[0] = vec![1, 2];
+        tc.containers.insert(0);
+        tc.toplevel_containers.insert(0);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 3];
-        Containment::new(1.0, true).apply(&ctx, &mut forces);
+        Containment::new(1.0, true).apply(&tc.view(), &mut forces);
         // Half strength → 0.5 * displacement.
         assert_eq!(forces[1], Vec2::new(-5.0, 0.0));
         assert_eq!(forces[2], Vec2::new(5.0, 0.0));
@@ -233,37 +146,18 @@ mod tests {
     fn hidden_child_excluded_from_centroid_and_application() {
         // Child 3 is hidden and way off to the side; it must not
         // participate in the centroid or receive a force.
-        let positions = vec![
+        let mut tc = TestCtx::new(vec![
             Vec2::ZERO,
             Vec2::new(10.0, 0.0),
             Vec2::new(-10.0, 0.0),
             Vec2::new(1000.0, 1000.0),
-        ];
-        let active = vec![true, true, true, false];
-        let children_of: Vec<Vec<usize>> = vec![vec![1, 2, 3], vec![], vec![], vec![]];
-        let mut containers = HashSet::new();
-        containers.insert(0);
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let sizes = vec![Vec2::ZERO; 4];
-        let degrees = vec![1.0; 4];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
+        ]);
+        tc.active[3] = false;
+        tc.children_of[0] = vec![1, 2, 3];
+        tc.containers.insert(0);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-        );
         let mut forces = vec![Vec2::ZERO; 4];
-        Containment::new(1.0, true).apply(&ctx, &mut forces);
+        Containment::new(1.0, true).apply(&tc.view(), &mut forces);
 
         assert_eq!(forces[3], Vec2::ZERO);
         // Centroid computed from 1 and 2 only = (0, 0).

--- a/crates/layout/src/forces/containment.rs
+++ b/crates/layout/src/forces/containment.rs
@@ -1,0 +1,273 @@
+//! Containment force: pull the direct children of a container toward
+//! their shared centroid.
+//!
+//! Each non-hidden container with at least two visible children computes
+//! the centroid of those children and pulls every child toward it by
+//! `strength * (centroid - position)`. Top-level containers (namespaces,
+//! translation units) use half strength so class-level containment wins
+//! the tug-of-war.
+
+use glam::Vec2;
+use std::any::Any;
+
+use super::{Force, ForceContext};
+
+/// Per-container children-toward-centroid force.
+pub struct Containment {
+    /// Whether this force is currently active.
+    pub enabled: bool,
+    /// Base strength for non-top-level containers. Top-level containers
+    /// (namespaces, translation units) get half of this.
+    pub strength: f32,
+}
+
+impl Containment {
+    /// Create a new containment force with the given parameters.
+    pub fn new(strength: f32, enabled: bool) -> Self {
+        Self { enabled, strength }
+    }
+}
+
+impl Force for Containment {
+    fn name(&self) -> &str {
+        "containment"
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
+        if self.strength <= 0.0 {
+            return;
+        }
+
+        for &c in ctx.containers {
+            if !ctx.active[c] {
+                continue;
+            }
+            let children = &ctx.children_of[c];
+            if children.len() < 2 {
+                continue;
+            }
+            let mut centroid = Vec2::ZERO;
+            let mut count = 0u32;
+            for &child in children {
+                if ctx.active[child] {
+                    centroid += ctx.positions[child];
+                    count += 1;
+                }
+            }
+            if count < 2 {
+                continue;
+            }
+            centroid /= count as f32;
+
+            let strength = if ctx.toplevel_containers.contains(&c) {
+                self.strength * 0.5
+            } else {
+                self.strength
+            };
+            for &child in children {
+                if ctx.active[child] {
+                    forces[child] += (centroid - ctx.positions[child]) * strength;
+                }
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_ir::EdgeKind;
+    use std::collections::HashSet;
+
+    fn mk_ctx<'a>(
+        positions: &'a [Vec2],
+        active: &'a [bool],
+        children_of: &'a [Vec<usize>],
+        containers: &'a HashSet<usize>,
+        expanded: &'a HashSet<usize>,
+        toplevel: &'a HashSet<usize>,
+        sizes: &'a [Vec2],
+        degrees: &'a [f32],
+        edge_pairs: &'a [(usize, usize, EdgeKind)],
+        visible_edge_kinds: &'a [EdgeKind],
+    ) -> ForceContext<'a> {
+        ForceContext {
+            positions,
+            sizes,
+            degrees,
+            active,
+            edge_pairs,
+            visible_edge_kinds,
+            children_of,
+            containers,
+            expanded,
+            toplevel_containers: toplevel,
+            node_count: positions.len(),
+        }
+    }
+
+    #[test]
+    fn singleton_child_receives_no_force() {
+        // Container 0 with a single child 1 — needs two visible children
+        // to do anything.
+        let positions = vec![Vec2::ZERO, Vec2::new(10.0, 0.0)];
+        let active = vec![true, true];
+        let children_of: Vec<Vec<usize>> = vec![vec![1], vec![]];
+        let mut containers = HashSet::new();
+        containers.insert(0);
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        Containment::new(1.0, true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn two_children_pulled_to_their_centroid() {
+        // Container 0 contains children 1 and 2 symmetric around origin.
+        let positions = vec![
+            Vec2::new(100.0, 100.0), // container (unused by children pull)
+            Vec2::new(10.0, 0.0),
+            Vec2::new(-10.0, 0.0),
+        ];
+        let active = vec![true, true, true];
+        let children_of: Vec<Vec<usize>> = vec![vec![1, 2], vec![], vec![]];
+        let mut containers = HashSet::new();
+        containers.insert(0);
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let sizes = vec![Vec2::ZERO; 3];
+        let degrees = vec![1.0; 3];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 3];
+        Containment::new(1.0, true).apply(&ctx, &mut forces);
+        // Centroid of children = origin. Each child pulled toward origin
+        // by 1.0 * displacement.
+        assert_eq!(forces[0], Vec2::ZERO);
+        assert_eq!(forces[1], Vec2::new(-10.0, 0.0));
+        assert_eq!(forces[2], Vec2::new(10.0, 0.0));
+    }
+
+    #[test]
+    fn toplevel_container_uses_half_strength() {
+        let positions = vec![Vec2::ZERO, Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
+        let active = vec![true, true, true];
+        let children_of: Vec<Vec<usize>> = vec![vec![1, 2], vec![], vec![]];
+        let mut containers = HashSet::new();
+        containers.insert(0);
+        let expanded = HashSet::new();
+        let mut toplevel = HashSet::new();
+        toplevel.insert(0);
+        let sizes = vec![Vec2::ZERO; 3];
+        let degrees = vec![1.0; 3];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 3];
+        Containment::new(1.0, true).apply(&ctx, &mut forces);
+        // Half strength → 0.5 * displacement.
+        assert_eq!(forces[1], Vec2::new(-5.0, 0.0));
+        assert_eq!(forces[2], Vec2::new(5.0, 0.0));
+    }
+
+    #[test]
+    fn hidden_child_excluded_from_centroid_and_application() {
+        // Child 3 is hidden and way off to the side; it must not
+        // participate in the centroid or receive a force.
+        let positions = vec![
+            Vec2::ZERO,
+            Vec2::new(10.0, 0.0),
+            Vec2::new(-10.0, 0.0),
+            Vec2::new(1000.0, 1000.0),
+        ];
+        let active = vec![true, true, true, false];
+        let children_of: Vec<Vec<usize>> = vec![vec![1, 2, 3], vec![], vec![], vec![]];
+        let mut containers = HashSet::new();
+        containers.insert(0);
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let sizes = vec![Vec2::ZERO; 4];
+        let degrees = vec![1.0; 4];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+        );
+        let mut forces = vec![Vec2::ZERO; 4];
+        Containment::new(1.0, true).apply(&ctx, &mut forces);
+
+        assert_eq!(forces[3], Vec2::ZERO);
+        // Centroid computed from 1 and 2 only = (0, 0).
+        assert_eq!(forces[1], Vec2::new(-10.0, 0.0));
+        assert_eq!(forces[2], Vec2::new(10.0, 0.0));
+    }
+}

--- a/crates/layout/src/forces/gravity.rs
+++ b/crates/layout/src/forces/gravity.rs
@@ -1,21 +1,16 @@
 //! Gentle pull toward the centroid of all visible nodes.
 //!
-//! Gravity keeps disconnected components from drifting away to infinity.
-//! It is the simplest force in the pipeline: compute the centroid of every
-//! active node once per step, then add `(centroid - position) * strength`
-//! to each active node's force accumulator.
+//! Gravity keeps disconnected components from drifting to infinity.
+//! Each step it computes the centroid of every active node and adds
+//! `strength * (centroid - position)` to every active node's force.
 
 use glam::Vec2;
 use std::any::Any;
 
 use super::{Force, ForceContext};
 
-/// Gentle centroid-attraction force.
-///
-/// Adding `strength * (centroid - position)` to every active node biases the
-/// whole graph toward its own center of mass, preventing disconnected
-/// components from drifting apart. A `strength` of `0.0` (or a negative
-/// value) makes the force a no-op, as does `enabled == false`.
+/// Gentle centroid-attraction force. A `strength` of `0.0` (or negative)
+/// makes `apply` a no-op, as does `enabled == false`.
 pub struct Gravity {
     /// Whether this force is currently toggled on in the pipeline.
     pub enabled: bool,
@@ -31,10 +26,6 @@ impl Gravity {
 }
 
 impl Force for Gravity {
-    fn name(&self) -> &str {
-        "gravity"
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -44,13 +35,10 @@ impl Force for Gravity {
     }
 
     fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
-        // A non-positive strength is an effective no-op and matches the
-        // original inline gravity code's `gravity > 0.0` gating.
         if self.strength <= 0.0 {
             return;
         }
 
-        // Centroid of all active (visible) nodes.
         let mut centroid = Vec2::ZERO;
         let mut count = 0u32;
         for (i, &active) in ctx.active.iter().enumerate() {
@@ -64,7 +52,6 @@ impl Force for Gravity {
         }
         centroid /= count as f32;
 
-        // Pull every active node toward that centroid.
         for (i, force) in forces.iter_mut().enumerate().take(ctx.node_count) {
             if ctx.active[i] {
                 *force += (centroid - ctx.positions[i]) * self.strength;
@@ -84,97 +71,23 @@ impl Force for Gravity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core_ir::EdgeKind;
-    use std::collections::HashSet;
-
-    fn mk_ctx<'a>(
-        positions: &'a [Vec2],
-        active: &'a [bool],
-        containers: &'a HashSet<usize>,
-        expanded: &'a HashSet<usize>,
-        toplevel: &'a HashSet<usize>,
-        children_of: &'a [Vec<usize>],
-        sizes: &'a [Vec2],
-        degrees: &'a [f32],
-        edge_pairs: &'a [(usize, usize, EdgeKind)],
-        visible_edge_kinds: &'a [EdgeKind],
-    ) -> ForceContext<'a> {
-        ForceContext {
-            positions,
-            sizes,
-            degrees,
-            active,
-            edge_pairs,
-            visible_edge_kinds,
-            children_of,
-            containers,
-            expanded,
-            toplevel_containers: toplevel,
-            node_count: positions.len(),
-        }
-    }
+    use crate::forces::test_utils::TestCtx;
 
     #[test]
     fn disabled_strength_is_noop() {
-        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible_edge_kinds: Vec<EdgeKind> = vec![];
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &containers,
-            &expanded,
-            &toplevel,
-            &children_of,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible_edge_kinds,
-        );
+        let tc = TestCtx::new(vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)]);
         let mut forces = vec![Vec2::ZERO; 2];
-
-        Gravity::new(0.0, true).apply(&ctx, &mut forces);
+        Gravity::new(0.0, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
     #[test]
     fn pulls_nodes_toward_centroid() {
-        // Two nodes symmetric around origin: centroid is origin, so both get
-        // pulled toward origin with equal and opposite forces.
-        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible_edge_kinds: Vec<EdgeKind> = vec![];
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &containers,
-            &expanded,
-            &toplevel,
-            &children_of,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible_edge_kinds,
-        );
+        // Two nodes symmetric around origin: centroid is origin, so both
+        // get pulled toward origin with equal and opposite forces.
+        let tc = TestCtx::new(vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)]);
         let mut forces = vec![Vec2::ZERO; 2];
-
-        Gravity::new(0.5, true).apply(&ctx, &mut forces);
+        Gravity::new(0.5, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces[0], Vec2::new(-5.0, 0.0));
         assert_eq!(forces[1], Vec2::new(5.0, 0.0));
     }
@@ -182,37 +95,15 @@ mod tests {
     #[test]
     fn hidden_nodes_are_skipped() {
         // Node 0 is hidden; centroid is computed from nodes 1 and 2 only.
-        let positions = vec![
+        let mut tc = TestCtx::new(vec![
             Vec2::new(100.0, 100.0),
             Vec2::new(2.0, 0.0),
             Vec2::new(-2.0, 0.0),
-        ];
-        let active = vec![false, true, true];
-        let sizes = vec![Vec2::ZERO; 3];
-        let degrees = vec![1.0; 3];
-        let children_of: Vec<Vec<usize>> = vec![vec![]; 3];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible_edge_kinds: Vec<EdgeKind> = vec![];
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &containers,
-            &expanded,
-            &toplevel,
-            &children_of,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible_edge_kinds,
-        );
+        ]);
+        tc.active[0] = false;
         let mut forces = vec![Vec2::ZERO; 3];
+        Gravity::new(1.0, true).apply(&tc.view(), &mut forces);
 
-        Gravity::new(1.0, true).apply(&ctx, &mut forces);
-        // Hidden node must not receive any force even though it's far away.
         assert_eq!(forces[0], Vec2::ZERO);
         // Centroid = (0, 0); each visible node pulled toward origin by strength=1.
         assert_eq!(forces[1], Vec2::new(-2.0, 0.0));

--- a/crates/layout/src/forces/gravity.rs
+++ b/crates/layout/src/forces/gravity.rs
@@ -1,0 +1,221 @@
+//! Gentle pull toward the centroid of all visible nodes.
+//!
+//! Gravity keeps disconnected components from drifting away to infinity.
+//! It is the simplest force in the pipeline: compute the centroid of every
+//! active node once per step, then add `(centroid - position) * strength`
+//! to each active node's force accumulator.
+
+use glam::Vec2;
+use std::any::Any;
+
+use super::{Force, ForceContext};
+
+/// Gentle centroid-attraction force.
+///
+/// Adding `strength * (centroid - position)` to every active node biases the
+/// whole graph toward its own center of mass, preventing disconnected
+/// components from drifting apart. A `strength` of `0.0` (or a negative
+/// value) makes the force a no-op, as does `enabled == false`.
+pub struct Gravity {
+    /// Whether this force is currently toggled on in the pipeline.
+    pub enabled: bool,
+    /// Pull coefficient. Multiplied into `(centroid - position)` per node.
+    pub strength: f32,
+}
+
+impl Gravity {
+    /// Create a new gravity force with the given strength and enabled flag.
+    pub fn new(strength: f32, enabled: bool) -> Self {
+        Self { enabled, strength }
+    }
+}
+
+impl Force for Gravity {
+    fn name(&self) -> &str {
+        "gravity"
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
+        // A non-positive strength is an effective no-op and matches the
+        // original inline gravity code's `gravity > 0.0` gating.
+        if self.strength <= 0.0 {
+            return;
+        }
+
+        // Centroid of all active (visible) nodes.
+        let mut centroid = Vec2::ZERO;
+        let mut count = 0u32;
+        for (i, &active) in ctx.active.iter().enumerate() {
+            if active {
+                centroid += ctx.positions[i];
+                count += 1;
+            }
+        }
+        if count == 0 {
+            return;
+        }
+        centroid /= count as f32;
+
+        // Pull every active node toward that centroid.
+        for (i, force) in forces.iter_mut().enumerate().take(ctx.node_count) {
+            if ctx.active[i] {
+                *force += (centroid - ctx.positions[i]) * self.strength;
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_ir::EdgeKind;
+    use std::collections::HashSet;
+
+    fn mk_ctx<'a>(
+        positions: &'a [Vec2],
+        active: &'a [bool],
+        containers: &'a HashSet<usize>,
+        expanded: &'a HashSet<usize>,
+        toplevel: &'a HashSet<usize>,
+        children_of: &'a [Vec<usize>],
+        sizes: &'a [Vec2],
+        degrees: &'a [f32],
+        edge_pairs: &'a [(usize, usize, EdgeKind)],
+        visible_edge_kinds: &'a [EdgeKind],
+    ) -> ForceContext<'a> {
+        ForceContext {
+            positions,
+            sizes,
+            degrees,
+            active,
+            edge_pairs,
+            visible_edge_kinds,
+            children_of,
+            containers,
+            expanded,
+            toplevel_containers: toplevel,
+            node_count: positions.len(),
+        }
+    }
+
+    #[test]
+    fn disabled_strength_is_noop() {
+        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible_edge_kinds: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &containers,
+            &expanded,
+            &toplevel,
+            &children_of,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible_edge_kinds,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+
+        Gravity::new(0.0, true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn pulls_nodes_toward_centroid() {
+        // Two nodes symmetric around origin: centroid is origin, so both get
+        // pulled toward origin with equal and opposite forces.
+        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible_edge_kinds: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &containers,
+            &expanded,
+            &toplevel,
+            &children_of,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible_edge_kinds,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+
+        Gravity::new(0.5, true).apply(&ctx, &mut forces);
+        assert_eq!(forces[0], Vec2::new(-5.0, 0.0));
+        assert_eq!(forces[1], Vec2::new(5.0, 0.0));
+    }
+
+    #[test]
+    fn hidden_nodes_are_skipped() {
+        // Node 0 is hidden; centroid is computed from nodes 1 and 2 only.
+        let positions = vec![
+            Vec2::new(100.0, 100.0),
+            Vec2::new(2.0, 0.0),
+            Vec2::new(-2.0, 0.0),
+        ];
+        let active = vec![false, true, true];
+        let sizes = vec![Vec2::ZERO; 3];
+        let degrees = vec![1.0; 3];
+        let children_of: Vec<Vec<usize>> = vec![vec![]; 3];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible_edge_kinds: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &containers,
+            &expanded,
+            &toplevel,
+            &children_of,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible_edge_kinds,
+        );
+        let mut forces = vec![Vec2::ZERO; 3];
+
+        Gravity::new(1.0, true).apply(&ctx, &mut forces);
+        // Hidden node must not receive any force even though it's far away.
+        assert_eq!(forces[0], Vec2::ZERO);
+        // Centroid = (0, 0); each visible node pulled toward origin by strength=1.
+        assert_eq!(forces[1], Vec2::new(-2.0, 0.0));
+        assert_eq!(forces[2], Vec2::new(2.0, 0.0));
+    }
+}

--- a/crates/layout/src/forces/grid.rs
+++ b/crates/layout/src/forces/grid.rs
@@ -1,0 +1,312 @@
+//! Spatial index for 2D point lookups inside a fixed cell neighbourhood.
+//!
+//! [`SpatialGrid::build`] buckets a set of `(index, position)` pairs
+//! into square cells of a given `cell_size`, then [`for_each_in_neighborhood`]
+//! visits every candidate index in the 3×3 cell window around a query
+//! position.
+//!
+//! The grid normally uses a dense flat vector indexed by `row * cols + col`,
+//! giving O(1) lookups with good cache locality and no hashing overhead.
+//! For pathological position spreads — a handful of points far apart,
+//! where the flat vector would be enormous and mostly empty — the
+//! builder falls back to a sparse [`HashMap`]-backed representation.
+//!
+//! Both the repulsion and container-overlap forces build one of these
+//! per step with different cell sizes and candidate sets.
+//!
+//! [`for_each_in_neighborhood`]: SpatialGrid::for_each_in_neighborhood
+
+use glam::Vec2;
+use std::collections::HashMap;
+
+/// Upper bound on `rows * cols` before the flat layout falls back to
+/// the hashmap fallback. 1M cells (≈24 MB of `Vec<usize>` headers at
+/// 24 bytes each) is well past what any reasonable graph needs — this
+/// threshold only trips when a single far-flung outlier blows up the
+/// bounding box.
+const FLAT_GRID_CELL_LIMIT: usize = 1_000_000;
+
+/// Spatial index for 2D point lookups inside a fixed cell neighbourhood.
+///
+/// Construct with [`SpatialGrid::build`], then compute a query cell key
+/// with [`SpatialGrid::cell_of`] and visit the 3×3 neighbourhood via
+/// [`SpatialGrid::for_each_in_neighborhood`].
+pub(crate) enum SpatialGrid {
+    /// Dense flat layout. `cells[row * cols + col]` holds the indices
+    /// that bucketed into `(col + origin_col, row + origin_row)`.
+    Flat {
+        cols: usize,
+        rows: usize,
+        origin_col: i32,
+        origin_row: i32,
+        inv_cell: f32,
+        cells: Vec<Vec<usize>>,
+    },
+    /// Sparse hashmap fallback keyed on the integer cell coordinate.
+    Hashed {
+        inv_cell: f32,
+        cells: HashMap<(i32, i32), Vec<usize>>,
+    },
+}
+
+impl SpatialGrid {
+    /// Build a grid from an iterator of `(index, position)` pairs.
+    ///
+    /// `cell_size` sets the granularity and must be strictly positive.
+    /// The resulting grid's 3×3 neighbourhood catches every pair of
+    /// points within `cell_size` of each other.
+    pub(crate) fn build<I>(cell_size: f32, iter: I) -> Self
+    where
+        I: IntoIterator<Item = (usize, Vec2)>,
+    {
+        debug_assert!(cell_size > 0.0);
+        let inv_cell = 1.0 / cell_size;
+
+        // First pass: compute each candidate's integer cell key and the
+        // enclosing cell-space bounding box.
+        let mut min_c = i32::MAX;
+        let mut max_c = i32::MIN;
+        let mut min_r = i32::MAX;
+        let mut max_r = i32::MIN;
+        let mut candidates: Vec<(usize, i32, i32)> = Vec::new();
+        for (i, pos) in iter {
+            let c = (pos.x * inv_cell).floor() as i32;
+            let r = (pos.y * inv_cell).floor() as i32;
+            candidates.push((i, c, r));
+            if c < min_c {
+                min_c = c;
+            }
+            if c > max_c {
+                max_c = c;
+            }
+            if r < min_r {
+                min_r = r;
+            }
+            if r > max_r {
+                max_r = r;
+            }
+        }
+
+        if candidates.is_empty() {
+            return Self::Hashed {
+                inv_cell,
+                cells: HashMap::new(),
+            };
+        }
+
+        // Span in i64 so extreme cell coordinates (from positions near
+        // the f32→i32 saturation limits) don't overflow the
+        // subtraction before we even get a chance to fall back.
+        let cols_span = (max_c as i64) - (min_c as i64) + 1;
+        let rows_span = (max_r as i64) - (min_r as i64) + 1;
+        let total = cols_span.saturating_mul(rows_span);
+
+        if total > FLAT_GRID_CELL_LIMIT as i64 {
+            // Sparse / pathological spread: fall back to hashed.
+            let mut cells: HashMap<(i32, i32), Vec<usize>> =
+                HashMap::with_capacity(candidates.len() / 4 + 1);
+            for (i, c, r) in candidates {
+                cells.entry((c, r)).or_default().push(i);
+            }
+            return Self::Hashed { inv_cell, cells };
+        }
+
+        // Spans now fit comfortably in `usize`. Per-candidate
+        // `c - min_c` likewise fits in `i32` because the span passed
+        // the limit check above.
+        let cols = cols_span as usize;
+        let rows = rows_span as usize;
+        let mut cells: Vec<Vec<usize>> = vec![Vec::new(); cols * rows];
+        for (i, c, r) in candidates {
+            let lc = (c - min_c) as usize;
+            let lr = (r - min_r) as usize;
+            cells[lr * cols + lc].push(i);
+        }
+
+        Self::Flat {
+            cols,
+            rows,
+            origin_col: min_c,
+            origin_row: min_r,
+            inv_cell,
+            cells,
+        }
+    }
+
+    /// Integer cell coordinate for a world-space position. The result
+    /// matches the key space used internally by both variants, so
+    /// [`for_each_in_neighborhood`](Self::for_each_in_neighborhood) can
+    /// consume it directly.
+    #[inline]
+    pub(crate) fn cell_of(&self, pos: Vec2) -> (i32, i32) {
+        let inv = match self {
+            Self::Flat { inv_cell, .. } | Self::Hashed { inv_cell, .. } => *inv_cell,
+        };
+        let c = (pos.x * inv).floor() as i32;
+        let r = (pos.y * inv).floor() as i32;
+        (c, r)
+    }
+
+    /// Invoke `f` once for every index bucketed into the 3×3 cell
+    /// neighbourhood centred on `query_cell`. Empty or out-of-range
+    /// cells are silently skipped.
+    ///
+    /// Local cell arithmetic runs in `i64` so extreme query keys
+    /// (produced when callers pass positions near the f32 → i32
+    /// saturation limit) can't overflow.
+    #[inline]
+    pub(crate) fn for_each_in_neighborhood<F: FnMut(usize)>(
+        &self,
+        query_cell: (i32, i32),
+        mut f: F,
+    ) {
+        let (qc, qr) = query_cell;
+        match self {
+            Self::Flat {
+                cols,
+                rows,
+                origin_col,
+                origin_row,
+                cells,
+                ..
+            } => {
+                let cols_i64 = *cols as i64;
+                let rows_i64 = *rows as i64;
+                let oc = *origin_col as i64;
+                let or = *origin_row as i64;
+                let qc_i64 = qc as i64;
+                let qr_i64 = qr as i64;
+                for dc in -1..=1i64 {
+                    for dr in -1..=1i64 {
+                        let lc = qc_i64 + dc - oc;
+                        let lr = qr_i64 + dr - or;
+                        if lc < 0 || lr < 0 || lc >= cols_i64 || lr >= rows_i64 {
+                            continue;
+                        }
+                        let idx = lr as usize * *cols + lc as usize;
+                        for &j in &cells[idx] {
+                            f(j);
+                        }
+                    }
+                }
+            }
+            Self::Hashed { cells, .. } => {
+                for dc in -1..=1i32 {
+                    for dr in -1..=1i32 {
+                        let key = (qc.wrapping_add(dc), qr.wrapping_add(dr));
+                        if let Some(bucket) = cells.get(&key) {
+                            for &j in bucket {
+                                f(j);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Collect every index returned by a 3×3 neighbourhood scan so
+    /// assertions can compare sets instead of depending on iteration
+    /// order.
+    fn collect_neighbors(grid: &SpatialGrid, query: (i32, i32)) -> Vec<usize> {
+        let mut out = Vec::new();
+        grid.for_each_in_neighborhood(query, |j| out.push(j));
+        out.sort_unstable();
+        out
+    }
+
+    #[test]
+    fn empty_input_builds_empty_hashed_grid() {
+        let grid = SpatialGrid::build(10.0, std::iter::empty());
+        assert!(matches!(grid, SpatialGrid::Hashed { .. }));
+        assert!(collect_neighbors(&grid, (0, 0)).is_empty());
+    }
+
+    #[test]
+    fn cell_of_matches_build() {
+        let positions = [
+            (0usize, Vec2::new(5.0, 5.0)),
+            (1usize, Vec2::new(25.0, 15.0)),
+        ];
+        let grid = SpatialGrid::build(10.0, positions.iter().copied());
+        // Node 0 at (5,5) → cell (0, 0). Node 1 at (25,15) → cell (2, 1).
+        assert_eq!(grid.cell_of(Vec2::new(5.0, 5.0)), (0, 0));
+        assert_eq!(grid.cell_of(Vec2::new(25.0, 15.0)), (2, 1));
+    }
+
+    #[test]
+    fn flat_grid_returns_nearby_indices() {
+        // 5 points arranged so some share a cell and some are in
+        // adjacent cells. cell_size = 10.
+        let positions = vec![
+            (0usize, Vec2::new(1.0, 1.0)),   // cell (0, 0)
+            (1usize, Vec2::new(2.0, 2.0)),   // cell (0, 0) — same as node 0
+            (2usize, Vec2::new(11.0, 1.0)),  // cell (1, 0) — adjacent
+            (3usize, Vec2::new(25.0, 25.0)), // cell (2, 2) — far
+            (4usize, Vec2::new(-5.0, 0.0)),  // cell (-1, 0) — adjacent
+        ];
+        let grid = SpatialGrid::build(10.0, positions.iter().copied());
+        assert!(matches!(grid, SpatialGrid::Flat { .. }));
+
+        // 3×3 neighbourhood around (0, 0) sees nodes 0, 1, 2, 4 (all
+        // within the 3×3 window) but not node 3 which is two cells away.
+        let neighbors = collect_neighbors(&grid, (0, 0));
+        assert_eq!(neighbors, vec![0, 1, 2, 4]);
+
+        // Around the far node's cell (2, 2), only node 3 itself.
+        let neighbors = collect_neighbors(&grid, (2, 2));
+        assert_eq!(neighbors, vec![3]);
+    }
+
+    #[test]
+    fn flat_grid_respects_bbox_edges() {
+        // Nodes all in the same cell. Querying a cell outside the grid
+        // bounds should return nothing instead of panicking.
+        let positions = [(0usize, Vec2::new(0.0, 0.0)), (1usize, Vec2::new(1.0, 1.0))];
+        let grid = SpatialGrid::build(10.0, positions.iter().copied());
+
+        // Query far outside the bbox — both the flat and hashed variants
+        // must silently return no hits.
+        assert!(collect_neighbors(&grid, (100, 100)).is_empty());
+        assert!(collect_neighbors(&grid, (-100, -100)).is_empty());
+    }
+
+    #[test]
+    fn pathological_spread_falls_back_to_hashed() {
+        // Two nodes at opposite ends of the world at a fine cell size.
+        // Cell-bbox is (1e6 + 1) × (1e6 + 1) ≫ FLAT_GRID_CELL_LIMIT, so
+        // the builder must pick the hashed variant.
+        let positions = [
+            (0usize, Vec2::new(0.0, 0.0)),
+            (1usize, Vec2::new(1.0e7, 1.0e7)),
+        ];
+        let grid = SpatialGrid::build(10.0, positions.iter().copied());
+        assert!(matches!(grid, SpatialGrid::Hashed { .. }));
+
+        // Both nodes are still individually findable.
+        let near_zero = collect_neighbors(&grid, grid.cell_of(Vec2::ZERO));
+        assert_eq!(near_zero, vec![0]);
+        let near_far = collect_neighbors(&grid, grid.cell_of(Vec2::new(1.0e7, 1.0e7)));
+        assert_eq!(near_far, vec![1]);
+    }
+
+    #[test]
+    fn hashed_variant_handles_negative_cell_keys() {
+        // Hashed grid should tolerate negative cell coordinates without
+        // the flat-grid's bbox translation.
+        let positions = [
+            (0usize, Vec2::new(-1.0e7, 0.0)),
+            (1usize, Vec2::new(1.0e7, 0.0)),
+        ];
+        let grid = SpatialGrid::build(10.0, positions.iter().copied());
+        assert!(matches!(grid, SpatialGrid::Hashed { .. }));
+
+        let near_neg = collect_neighbors(&grid, grid.cell_of(Vec2::new(-1.0e7, 0.0)));
+        assert_eq!(near_neg, vec![0]);
+    }
+}

--- a/crates/layout/src/forces/location_affinity.rs
+++ b/crates/layout/src/forces/location_affinity.rs
@@ -1,0 +1,297 @@
+//! Directory-affinity force: cluster nodes that share filesystem directories.
+//!
+//! Nodes whose source locations share a directory prefix at some depth are
+//! pulled toward the centroid of their group. Deeper (more specific)
+//! prefixes get the full strength; shallower levels decay by
+//! `falloff.powi(depth)` so same-directory attraction dominates over
+//! same-grandparent.
+//!
+//! The directory grouping is precomputed once at construction time and
+//! owned by this force — before the refactor it lived on `LayoutState`
+//! as `dir_groups` and `max_dir_depth`.
+
+use glam::Vec2;
+use std::any::Any;
+
+use super::{Force, ForceContext};
+
+/// Directory-affinity clustering force.
+pub struct LocationAffinity {
+    /// Whether this force is currently active.
+    pub enabled: bool,
+    /// Base strength at the deepest directory level.
+    pub strength: f32,
+    /// Per-level decay. `0.5` means each level up halves the attraction.
+    pub falloff: f32,
+    /// `dir_groups[depth][group_idx]` is a list of node indices sharing the
+    /// same directory prefix at `depth`. Groups with fewer than two members
+    /// are not stored (a singleton group produces no force).
+    pub dir_groups: Vec<Vec<Vec<usize>>>,
+    /// Maximum directory depth across all nodes (cached for force scaling).
+    pub max_dir_depth: usize,
+}
+
+impl LocationAffinity {
+    /// Create a new location-affinity force from precomputed directory
+    /// groups. `max_dir_depth` should equal
+    /// `dir_groups.len().saturating_sub(1)` — the caller typically computes
+    /// this alongside the groups themselves.
+    pub fn new(
+        strength: f32,
+        falloff: f32,
+        dir_groups: Vec<Vec<Vec<usize>>>,
+        max_dir_depth: usize,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            enabled,
+            strength,
+            falloff,
+            dir_groups,
+            max_dir_depth,
+        }
+    }
+}
+
+impl Force for LocationAffinity {
+    fn name(&self) -> &str {
+        "location_affinity"
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
+        if self.strength <= 0.0 || self.dir_groups.is_empty() {
+            return;
+        }
+        let max_d = self.max_dir_depth;
+        for (depth, groups_at_depth) in self.dir_groups.iter().enumerate() {
+            // Deeper = more specific = stronger. Scale so the deepest
+            // level gets full strength and shallower levels decay.
+            let level_scale = if max_d > 0 {
+                self.falloff.powi((max_d - depth) as i32)
+            } else {
+                1.0
+            };
+            let strength = self.strength * level_scale;
+            if strength < 1e-6 {
+                continue;
+            }
+
+            for group in groups_at_depth {
+                // Compute centroid of visible nodes in this group.
+                let mut centroid = Vec2::ZERO;
+                let mut count = 0u32;
+                for &idx in group {
+                    if ctx.active[idx] {
+                        centroid += ctx.positions[idx];
+                        count += 1;
+                    }
+                }
+                if count < 2 {
+                    continue;
+                }
+                centroid /= count as f32;
+
+                for &idx in group {
+                    if ctx.active[idx] {
+                        forces[idx] += (centroid - ctx.positions[idx]) * strength;
+                    }
+                }
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_ir::EdgeKind;
+    use std::collections::HashSet;
+
+    fn mk_ctx<'a>(
+        positions: &'a [Vec2],
+        active: &'a [bool],
+        sizes: &'a [Vec2],
+        degrees: &'a [f32],
+        edge_pairs: &'a [(usize, usize, EdgeKind)],
+        visible_edge_kinds: &'a [EdgeKind],
+        children_of: &'a [Vec<usize>],
+        containers: &'a HashSet<usize>,
+        expanded: &'a HashSet<usize>,
+        toplevel: &'a HashSet<usize>,
+    ) -> ForceContext<'a> {
+        ForceContext {
+            positions,
+            sizes,
+            degrees,
+            active,
+            edge_pairs,
+            visible_edge_kinds,
+            children_of,
+            containers,
+            expanded,
+            toplevel_containers: toplevel,
+            node_count: positions.len(),
+        }
+    }
+
+    #[test]
+    fn empty_groups_is_noop() {
+        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        LocationAffinity::new(1.0, 0.5, vec![], 0, true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn nodes_in_same_group_pulled_to_centroid() {
+        // Two nodes forming one group, symmetric around the origin.
+        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let dir_groups = vec![vec![vec![0usize, 1usize]]];
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        // max_dir_depth = 0, so level_scale = 1.0 and strength = 0.5 applies
+        // fully. Nodes pulled toward centroid (origin) by 0.5 * displacement.
+        LocationAffinity::new(0.5, 0.5, dir_groups, 0, true).apply(&ctx, &mut forces);
+        assert_eq!(forces[0], Vec2::new(-5.0, 0.0));
+        assert_eq!(forces[1], Vec2::new(5.0, 0.0));
+    }
+
+    #[test]
+    fn hidden_nodes_ignored_in_centroid_and_application() {
+        // Three nodes, node 0 is hidden. Centroid computed from 1 and 2
+        // only, and node 0 receives no force despite being listed in
+        // the group.
+        let positions = vec![
+            Vec2::new(100.0, 100.0),
+            Vec2::new(10.0, 0.0),
+            Vec2::new(-10.0, 0.0),
+        ];
+        let active = vec![false, true, true];
+        let sizes = vec![Vec2::ZERO; 3];
+        let degrees = vec![1.0; 3];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+        let children_of: Vec<Vec<usize>> = vec![vec![]; 3];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let dir_groups = vec![vec![vec![0usize, 1usize, 2usize]]];
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 3];
+        LocationAffinity::new(1.0, 0.5, dir_groups, 0, true).apply(&ctx, &mut forces);
+
+        assert_eq!(forces[0], Vec2::ZERO);
+        // Centroid of visible = (0, 0).
+        assert_eq!(forces[1], Vec2::new(-10.0, 0.0));
+        assert_eq!(forces[2], Vec2::new(10.0, 0.0));
+    }
+
+    #[test]
+    fn falloff_weakens_shallow_levels() {
+        // One group at depth 0, one at depth 1; max depth = 1.
+        // Shallower (depth 0) level gets strength * falloff^1.
+        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible: Vec<EdgeKind> = vec![];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        // Only the shallow group present — force should be scaled by falloff.
+        let dir_groups = vec![vec![vec![0usize, 1usize]], vec![]];
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        LocationAffinity::new(1.0, 0.5, dir_groups, 1, true).apply(&ctx, &mut forces);
+
+        // Level scale at depth 0 with max_d=1 is falloff^(1-0) = 0.5.
+        // Expected force: 0.5 * (centroid - position) = 0.5 * (-10, 0) = (-5, 0).
+        assert_eq!(forces[0], Vec2::new(-5.0, 0.0));
+        assert_eq!(forces[1], Vec2::new(5.0, 0.0));
+    }
+}

--- a/crates/layout/src/forces/location_affinity.rs
+++ b/crates/layout/src/forces/location_affinity.rs
@@ -1,14 +1,11 @@
-//! Directory-affinity force: cluster nodes that share filesystem directories.
+//! Directory-affinity force: cluster nodes that share filesystem
+//! directories.
 //!
-//! Nodes whose source locations share a directory prefix at some depth are
-//! pulled toward the centroid of their group. Deeper (more specific)
+//! Nodes whose source locations share a directory prefix at some depth
+//! are pulled toward the centroid of their group. Deeper (more specific)
 //! prefixes get the full strength; shallower levels decay by
 //! `falloff.powi(depth)` so same-directory attraction dominates over
 //! same-grandparent.
-//!
-//! The directory grouping is precomputed once at construction time and
-//! owned by this force — before the refactor it lived on `LayoutState`
-//! as `dir_groups` and `max_dir_depth`.
 
 use glam::Vec2;
 use std::any::Any;
@@ -23,19 +20,19 @@ pub struct LocationAffinity {
     pub strength: f32,
     /// Per-level decay. `0.5` means each level up halves the attraction.
     pub falloff: f32,
-    /// `dir_groups[depth][group_idx]` is a list of node indices sharing the
-    /// same directory prefix at `depth`. Groups with fewer than two members
-    /// are not stored (a singleton group produces no force).
-    pub dir_groups: Vec<Vec<Vec<usize>>>,
+    /// `dir_groups[depth][group_idx]` is a list of node indices sharing
+    /// the same directory prefix at `depth`. Groups with fewer than two
+    /// members are not stored (a singleton group produces no force).
+    dir_groups: Vec<Vec<Vec<usize>>>,
     /// Maximum directory depth across all nodes (cached for force scaling).
-    pub max_dir_depth: usize,
+    max_dir_depth: usize,
 }
 
 impl LocationAffinity {
     /// Create a new location-affinity force from precomputed directory
     /// groups. `max_dir_depth` should equal
-    /// `dir_groups.len().saturating_sub(1)` — the caller typically computes
-    /// this alongside the groups themselves.
+    /// `dir_groups.len().saturating_sub(1)` — the caller typically
+    /// computes this alongside the groups themselves.
     pub fn new(
         strength: f32,
         falloff: f32,
@@ -54,10 +51,6 @@ impl LocationAffinity {
 }
 
 impl Force for LocationAffinity {
-    fn name(&self) -> &str {
-        "location_affinity"
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -85,7 +78,6 @@ impl Force for LocationAffinity {
             }
 
             for group in groups_at_depth {
-                // Compute centroid of visible nodes in this group.
                 let mut centroid = Vec2::ZERO;
                 let mut count = 0u32;
                 for &idx in group {
@@ -120,177 +112,59 @@ impl Force for LocationAffinity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core_ir::EdgeKind;
-    use std::collections::HashSet;
-
-    fn mk_ctx<'a>(
-        positions: &'a [Vec2],
-        active: &'a [bool],
-        sizes: &'a [Vec2],
-        degrees: &'a [f32],
-        edge_pairs: &'a [(usize, usize, EdgeKind)],
-        visible_edge_kinds: &'a [EdgeKind],
-        children_of: &'a [Vec<usize>],
-        containers: &'a HashSet<usize>,
-        expanded: &'a HashSet<usize>,
-        toplevel: &'a HashSet<usize>,
-    ) -> ForceContext<'a> {
-        ForceContext {
-            positions,
-            sizes,
-            degrees,
-            active,
-            edge_pairs,
-            visible_edge_kinds,
-            children_of,
-            containers,
-            expanded,
-            toplevel_containers: toplevel,
-            node_count: positions.len(),
-        }
-    }
+    use crate::forces::test_utils::TestCtx;
 
     #[test]
     fn empty_groups_is_noop() {
-        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
+        let tc = TestCtx::new(vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)]);
         let mut forces = vec![Vec2::ZERO; 2];
-        LocationAffinity::new(1.0, 0.5, vec![], 0, true).apply(&ctx, &mut forces);
+        LocationAffinity::new(1.0, 0.5, vec![], 0, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
     #[test]
     fn nodes_in_same_group_pulled_to_centroid() {
-        // Two nodes forming one group, symmetric around the origin.
-        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-
+        let tc = TestCtx::new(vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)]);
         let dir_groups = vec![vec![vec![0usize, 1usize]]];
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        // max_dir_depth = 0, so level_scale = 1.0 and strength = 0.5 applies
-        // fully. Nodes pulled toward centroid (origin) by 0.5 * displacement.
-        LocationAffinity::new(0.5, 0.5, dir_groups, 0, true).apply(&ctx, &mut forces);
+        // max_dir_depth = 0, so level_scale = 1.0 and strength = 0.5
+        // applies in full. Nodes pulled toward centroid (origin).
+        LocationAffinity::new(0.5, 0.5, dir_groups, 0, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces[0], Vec2::new(-5.0, 0.0));
         assert_eq!(forces[1], Vec2::new(5.0, 0.0));
     }
 
     #[test]
     fn hidden_nodes_ignored_in_centroid_and_application() {
-        // Three nodes, node 0 is hidden. Centroid computed from 1 and 2
-        // only, and node 0 receives no force despite being listed in
-        // the group.
-        let positions = vec![
+        // Three nodes, node 0 is hidden. Centroid comes from 1 and 2
+        // only, and node 0 receives no force despite being in the group.
+        let mut tc = TestCtx::new(vec![
             Vec2::new(100.0, 100.0),
             Vec2::new(10.0, 0.0),
             Vec2::new(-10.0, 0.0),
-        ];
-        let active = vec![false, true, true];
-        let sizes = vec![Vec2::ZERO; 3];
-        let degrees = vec![1.0; 3];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
-        let children_of: Vec<Vec<usize>> = vec![vec![]; 3];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
+        ]);
+        tc.active[0] = false;
 
         let dir_groups = vec![vec![vec![0usize, 1usize, 2usize]]];
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 3];
-        LocationAffinity::new(1.0, 0.5, dir_groups, 0, true).apply(&ctx, &mut forces);
+        LocationAffinity::new(1.0, 0.5, dir_groups, 0, true).apply(&tc.view(), &mut forces);
 
         assert_eq!(forces[0], Vec2::ZERO);
-        // Centroid of visible = (0, 0).
         assert_eq!(forces[1], Vec2::new(-10.0, 0.0));
         assert_eq!(forces[2], Vec2::new(10.0, 0.0));
     }
 
     #[test]
     fn falloff_weakens_shallow_levels() {
-        // One group at depth 0, one at depth 1; max depth = 1.
-        // Shallower (depth 0) level gets strength * falloff^1.
-        let positions = vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible: Vec<EdgeKind> = vec![];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-
-        // Only the shallow group present — force should be scaled by falloff.
+        // One group at depth 0 with max depth = 1. The shallow level
+        // gets strength * falloff^1.
+        let tc = TestCtx::new(vec![Vec2::new(10.0, 0.0), Vec2::new(-10.0, 0.0)]);
         let dir_groups = vec![vec![vec![0usize, 1usize]], vec![]];
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        LocationAffinity::new(1.0, 0.5, dir_groups, 1, true).apply(&ctx, &mut forces);
+        LocationAffinity::new(1.0, 0.5, dir_groups, 1, true).apply(&tc.view(), &mut forces);
 
-        // Level scale at depth 0 with max_d=1 is falloff^(1-0) = 0.5.
-        // Expected force: 0.5 * (centroid - position) = 0.5 * (-10, 0) = (-5, 0).
+        // Level scale at depth 0 with max_d=1 is 0.5^1 = 0.5.
+        // Expected force: 0.5 * (centroid - position) = 0.5 * (-10, 0).
         assert_eq!(forces[0], Vec2::new(-5.0, 0.0));
         assert_eq!(forces[1], Vec2::new(5.0, 0.0));
     }

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -17,11 +17,13 @@ use glam::Vec2;
 use std::any::Any;
 use std::collections::HashSet;
 
+pub mod containment;
 pub mod gravity;
 pub mod location_affinity;
 pub mod repulsion;
 pub mod spring_attraction;
 
+pub use containment::Containment;
 pub use gravity::Gravity;
 pub use location_affinity::LocationAffinity;
 pub use repulsion::Repulsion;

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -7,15 +7,19 @@
 //! and references, so forces always see the current positions, sizes,
 //! visibility, and topology.
 //!
-//! This module is currently scaffolding: the individual force
-//! implementations (repulsion, spring attraction, gravity, location affinity,
-//! containment, container repulsion) will be added in later steps of the
-//! layout refactor. Until then, [`crate::LayoutState::step_inner`] continues
-//! to compute forces inline.
+//! Forces are progressively extracted from [`crate::LayoutState::step_inner`]
+//! into this module. Each extraction step leaves the simulation's overall
+//! behavior unchanged — the inline computation is replaced with a call into
+//! the pipeline. See issue #33 for the full migration plan.
 
 use core_ir::EdgeKind;
 use glam::Vec2;
+use std::any::Any;
 use std::collections::HashSet;
+
+pub mod gravity;
+
+pub use gravity::Gravity;
 
 /// Read-only snapshot of simulation state shared with every [`Force`] during
 /// a single simulation step.
@@ -75,7 +79,13 @@ pub struct ForceContext<'a> {
 /// force application across rayon threads. Within a single `apply` call,
 /// forces read only the shared context and write only into their slice of
 /// the `forces` buffer — no interior mutability required.
-pub trait Force: Send + Sync {
+///
+/// The `Any` super-trait allows [`crate::LayoutState`] to downcast boxed
+/// forces back to their concrete type. This is used internally to sync
+/// parameters from the legacy [`crate::ForceParams`] struct, and will later
+/// back the `force::<T>()` / `force_mut::<T>()` typed accessors used by the
+/// viz crate (see issue #33, Phase 3).
+pub trait Force: Any + Send + Sync {
     /// Short human-readable identifier, used for UI headers and debug logs.
     fn name(&self) -> &str;
 
@@ -93,4 +103,10 @@ pub trait Force: Send + Sync {
     /// - Add to `forces[i]` rather than overwrite — multiple forces stack.
     /// - Avoid reading or writing outside `0..ctx.node_count`.
     fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]);
+
+    /// Upcast to `&dyn Any` so callers can downcast to the concrete type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Upcast to `&mut dyn Any` so callers can downcast to the concrete type.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -2,15 +2,10 @@
 //!
 //! Each force type implements the [`Force`] trait and accumulates
 //! contributions into a shared `forces` buffer during [`Force::apply`].
-//! [`ForceContext`] bundles the read-only simulation state that every force
-//! needs each step — it is rebuilt cheaply on each tick from borrowed slices
-//! and references, so forces always see the current positions, sizes,
-//! visibility, and topology.
-//!
-//! Forces are progressively extracted from [`crate::LayoutState::step_inner`]
-//! into this module. Each extraction step leaves the simulation's overall
-//! behavior unchanged — the inline computation is replaced with a call into
-//! the pipeline. See issue #33 for the full migration plan.
+//! [`ForceContext`] bundles the read-only simulation state every force
+//! needs each step — it is rebuilt cheaply on each tick from borrowed
+//! slices and references, so forces always see the current positions,
+//! sizes, visibility, and topology.
 
 use core_ir::EdgeKind;
 use glam::Vec2;
@@ -32,22 +27,12 @@ pub use repulsion::Repulsion;
 pub use spring_attraction::SpringAttraction;
 
 /// Threshold (in nodes) above which forces may parallelise their inner
-/// loops under rayon. For smaller graphs, the overhead of spawning work
-/// onto the thread pool outweighs the savings, so forces fall back to a
-/// serial implementation.
+/// loops under rayon. Below this, the thread-pool overhead outweighs
+/// the savings and forces fall back to serial execution.
 pub(crate) const PARALLEL_THRESHOLD: usize = 500;
 
-/// Read-only snapshot of simulation state shared with every [`Force`] during
-/// a single simulation step.
-///
-/// A `ForceContext` is reconstructed at the start of each step from borrowed
-/// slices and references owned by [`crate::LayoutState`], so it is cheap to
-/// build and forces always observe the current state.
-///
-/// Forces must not attempt to mutate any of these fields; mutation happens
-/// through the `forces` buffer passed to [`Force::apply`] and is integrated
-/// into positions/velocities by [`crate::LayoutState`] after all forces have
-/// run.
+/// Read-only snapshot of simulation state shared with every [`Force`]
+/// during a single simulation step.
 #[non_exhaustive]
 pub struct ForceContext<'a> {
     /// Current world-space positions, indexed by node index.
@@ -58,71 +43,119 @@ pub struct ForceContext<'a> {
     /// Per-node edge degree, used to normalize spring forces on hub nodes.
     pub degrees: &'a [f32],
     /// Per-node active flag. `active[i] == true` means node `i` is visible
-    /// and participates in force computation this step. Hidden nodes
-    /// (collapsed descendants, file-tree hidden) are `false`.
+    /// and participates in force computation this step.
     pub active: &'a [bool],
     /// Edge topology as `(from_idx, to_idx, kind)` triples.
     pub edge_pairs: &'a [(usize, usize, EdgeKind)],
-    /// Edge kinds currently toggled on in the UI. Forces that spring along
-    /// edges should skip pairs whose kind is not in this list.
+    /// Edge kinds currently toggled on in the UI.
     pub visible_edge_kinds: &'a [EdgeKind],
-    /// Container-hierarchy children lookup: `children_of[i]` is the list of
-    /// node indices directly contained by node `i` (empty if `i` is not a
-    /// container).
+    /// `children_of[i]` is the list of node indices directly contained by
+    /// node `i` (empty if `i` is not a container).
     pub children_of: &'a [Vec<usize>],
     /// Set of node indices that are containers (have ≥1 `Contains` child).
     pub containers: &'a HashSet<usize>,
-    /// Set of container node indices currently expanded (children visible).
+    /// Container indices currently expanded (children visible).
     pub expanded: &'a HashSet<usize>,
-    /// Containers that live at the top level of the hierarchy (namespaces,
-    /// translation units). These typically receive a reduced containment
-    /// strength.
+    /// Containers at the top of the hierarchy (namespaces, translation
+    /// units). These typically get a reduced containment strength.
     pub toplevel_containers: &'a HashSet<usize>,
-    /// Total number of nodes in the simulation (length of `positions`,
-    /// `sizes`, `degrees`, `active`).
+    /// Total number of nodes (length of `positions`, `sizes`, `degrees`,
+    /// `active`).
     pub node_count: usize,
 }
 
 /// A composable force in the layout simulation.
 ///
-/// Forces are held by [`crate::LayoutState`] as a `Vec<Box<dyn Force>>` and
-/// run in order each step. Every enabled force gets a mutable view of the
-/// shared `forces` accumulator and a read-only [`ForceContext`]; after all
-/// forces run, the accumulated contributions are integrated into velocities
-/// and positions.
+/// Forces are held by [`crate::LayoutState`] as `Vec<Box<dyn Force>>` and
+/// run in order each step. Each enabled force accumulates contributions
+/// into a shared `forces` buffer, which is integrated into velocities
+/// and positions after all forces have run.
 ///
-/// Implementors must be `Send + Sync` so the pipeline can eventually fan out
-/// force application across rayon threads. Within a single `apply` call,
-/// forces read only the shared context and write only into their slice of
-/// the `forces` buffer — no interior mutability required.
-///
-/// The `Any` super-trait allows [`crate::LayoutState`] to downcast boxed
-/// forces back to their concrete type. This is used internally to sync
-/// parameters from the legacy [`crate::ForceParams`] struct, and will later
-/// back the `force::<T>()` / `force_mut::<T>()` typed accessors used by the
-/// viz crate (see issue #33, Phase 3).
+/// Implementors must be `Send + Sync` so the pipeline can fan out across
+/// rayon threads. The `Any` super-trait lets callers downcast boxed
+/// forces back to their concrete type to read or mutate tunable fields.
 pub trait Force: Any + Send + Sync {
-    /// Short human-readable identifier, used for UI headers and debug logs.
-    fn name(&self) -> &str;
-
-    /// Whether this force is currently active. A disabled force is skipped
-    /// entirely by the pipeline and contributes nothing to `forces`.
+    /// Whether this force is currently active. A disabled force is
+    /// skipped by the pipeline and contributes nothing.
     fn enabled(&self) -> bool;
 
     /// Toggle this force on or off.
     fn set_enabled(&mut self, enabled: bool);
 
-    /// Accumulate this force's contribution into `forces[i]` for each active
-    /// node `i`. Implementors must:
-    ///
-    /// - Only write to indices where `ctx.active[i]` is `true`.
-    /// - Add to `forces[i]` rather than overwrite — multiple forces stack.
-    /// - Avoid reading or writing outside `0..ctx.node_count`.
+    /// Accumulate this force's contribution into `forces[i]` for each
+    /// active node `i`. Implementors must only write to indices where
+    /// `ctx.active[i]` is `true`, add to `forces[i]` rather than
+    /// overwrite, and avoid reading or writing outside
+    /// `0..ctx.node_count`.
     fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]);
 
-    /// Upcast to `&dyn Any` so callers can downcast to the concrete type.
+    /// Upcast to `&dyn Any` for downcasting to the concrete type.
     fn as_any(&self) -> &dyn Any;
 
-    /// Upcast to `&mut dyn Any` so callers can downcast to the concrete type.
+    /// Upcast to `&mut dyn Any` for downcasting to the concrete type.
     fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    //! Shared constructors for force unit tests.
+    //!
+    //! Most force tests only care about a few slices (positions, active,
+    //! perhaps edges or children). [`TestCtx`] owns everything a
+    //! [`ForceContext`] needs to borrow so tests can build one in a few
+    //! lines instead of repeating the full field list.
+    use super::*;
+
+    /// Owned backing storage for a [`ForceContext`]. Populate the fields
+    /// you care about, leave the rest at their defaults, then call
+    /// [`TestCtx::view`] to get a borrowed `ForceContext`.
+    pub struct TestCtx {
+        pub positions: Vec<Vec2>,
+        pub active: Vec<bool>,
+        pub sizes: Vec<Vec2>,
+        pub degrees: Vec<f32>,
+        pub edge_pairs: Vec<(usize, usize, EdgeKind)>,
+        pub visible_edge_kinds: Vec<EdgeKind>,
+        pub children_of: Vec<Vec<usize>>,
+        pub containers: HashSet<usize>,
+        pub expanded: HashSet<usize>,
+        pub toplevel_containers: HashSet<usize>,
+    }
+
+    impl TestCtx {
+        /// New test context for `positions` with every node active.
+        /// All other fields start empty; callers set what they need.
+        pub fn new(positions: Vec<Vec2>) -> Self {
+            let n = positions.len();
+            Self {
+                positions,
+                active: vec![true; n],
+                sizes: vec![Vec2::ZERO; n],
+                degrees: vec![1.0; n],
+                edge_pairs: Vec::new(),
+                visible_edge_kinds: Vec::new(),
+                children_of: vec![Vec::new(); n],
+                containers: HashSet::new(),
+                expanded: HashSet::new(),
+                toplevel_containers: HashSet::new(),
+            }
+        }
+
+        /// Borrow all fields as a [`ForceContext`].
+        pub fn view(&self) -> ForceContext<'_> {
+            ForceContext {
+                positions: &self.positions,
+                sizes: &self.sizes,
+                degrees: &self.degrees,
+                active: &self.active,
+                edge_pairs: &self.edge_pairs,
+                visible_edge_kinds: &self.visible_edge_kinds,
+                children_of: &self.children_of,
+                containers: &self.containers,
+                expanded: &self.expanded,
+                toplevel_containers: &self.toplevel_containers,
+                node_count: self.positions.len(),
+            }
+        }
+    }
 }

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -19,9 +19,11 @@ use std::collections::HashSet;
 
 pub mod gravity;
 pub mod repulsion;
+pub mod spring_attraction;
 
 pub use gravity::Gravity;
 pub use repulsion::Repulsion;
+pub use spring_attraction::SpringAttraction;
 
 /// Threshold (in nodes) above which forces may parallelise their inner
 /// loops under rayon. For smaller graphs, the overhead of spawning work

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -18,8 +18,16 @@ use std::any::Any;
 use std::collections::HashSet;
 
 pub mod gravity;
+pub mod repulsion;
 
 pub use gravity::Gravity;
+pub use repulsion::Repulsion;
+
+/// Threshold (in nodes) above which forces may parallelise their inner
+/// loops under rayon. For smaller graphs, the overhead of spawning work
+/// onto the thread pool outweighs the savings, so forces fall back to a
+/// serial implementation.
+pub(crate) const PARALLEL_THRESHOLD: usize = 500;
 
 /// Read-only snapshot of simulation state shared with every [`Force`] during
 /// a single simulation step.

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -1,0 +1,96 @@
+//! Composable force pipeline for the force-directed layout simulation.
+//!
+//! Each force type implements the [`Force`] trait and accumulates
+//! contributions into a shared `forces` buffer during [`Force::apply`].
+//! [`ForceContext`] bundles the read-only simulation state that every force
+//! needs each step — it is rebuilt cheaply on each tick from borrowed slices
+//! and references, so forces always see the current positions, sizes,
+//! visibility, and topology.
+//!
+//! This module is currently scaffolding: the individual force
+//! implementations (repulsion, spring attraction, gravity, location affinity,
+//! containment, container repulsion) will be added in later steps of the
+//! layout refactor. Until then, [`crate::LayoutState::step_inner`] continues
+//! to compute forces inline.
+
+use core_ir::EdgeKind;
+use glam::Vec2;
+use std::collections::HashSet;
+
+/// Read-only snapshot of simulation state shared with every [`Force`] during
+/// a single simulation step.
+///
+/// A `ForceContext` is reconstructed at the start of each step from borrowed
+/// slices and references owned by [`crate::LayoutState`], so it is cheap to
+/// build and forces always observe the current state.
+///
+/// Forces must not attempt to mutate any of these fields; mutation happens
+/// through the `forces` buffer passed to [`Force::apply`] and is integrated
+/// into positions/velocities by [`crate::LayoutState`] after all forces have
+/// run.
+#[non_exhaustive]
+pub struct ForceContext<'a> {
+    /// Current world-space positions, indexed by node index.
+    pub positions: &'a [Vec2],
+    /// Per-node bounding-box sizes in world units. Used by size-aware
+    /// repulsion (edge-to-edge rather than center-to-center).
+    pub sizes: &'a [Vec2],
+    /// Per-node edge degree, used to normalize spring forces on hub nodes.
+    pub degrees: &'a [f32],
+    /// Per-node active flag. `active[i] == true` means node `i` is visible
+    /// and participates in force computation this step. Hidden nodes
+    /// (collapsed descendants, file-tree hidden) are `false`.
+    pub active: &'a [bool],
+    /// Edge topology as `(from_idx, to_idx, kind)` triples.
+    pub edge_pairs: &'a [(usize, usize, EdgeKind)],
+    /// Edge kinds currently toggled on in the UI. Forces that spring along
+    /// edges should skip pairs whose kind is not in this list.
+    pub visible_edge_kinds: &'a [EdgeKind],
+    /// Container-hierarchy children lookup: `children_of[i]` is the list of
+    /// node indices directly contained by node `i` (empty if `i` is not a
+    /// container).
+    pub children_of: &'a [Vec<usize>],
+    /// Set of node indices that are containers (have ≥1 `Contains` child).
+    pub containers: &'a HashSet<usize>,
+    /// Set of container node indices currently expanded (children visible).
+    pub expanded: &'a HashSet<usize>,
+    /// Containers that live at the top level of the hierarchy (namespaces,
+    /// translation units). These typically receive a reduced containment
+    /// strength.
+    pub toplevel_containers: &'a HashSet<usize>,
+    /// Total number of nodes in the simulation (length of `positions`,
+    /// `sizes`, `degrees`, `active`).
+    pub node_count: usize,
+}
+
+/// A composable force in the layout simulation.
+///
+/// Forces are held by [`crate::LayoutState`] as a `Vec<Box<dyn Force>>` and
+/// run in order each step. Every enabled force gets a mutable view of the
+/// shared `forces` accumulator and a read-only [`ForceContext`]; after all
+/// forces run, the accumulated contributions are integrated into velocities
+/// and positions.
+///
+/// Implementors must be `Send + Sync` so the pipeline can eventually fan out
+/// force application across rayon threads. Within a single `apply` call,
+/// forces read only the shared context and write only into their slice of
+/// the `forces` buffer — no interior mutability required.
+pub trait Force: Send + Sync {
+    /// Short human-readable identifier, used for UI headers and debug logs.
+    fn name(&self) -> &str;
+
+    /// Whether this force is currently active. A disabled force is skipped
+    /// entirely by the pipeline and contributes nothing to `forces`.
+    fn enabled(&self) -> bool;
+
+    /// Toggle this force on or off.
+    fn set_enabled(&mut self, enabled: bool);
+
+    /// Accumulate this force's contribution into `forces[i]` for each active
+    /// node `i`. Implementors must:
+    ///
+    /// - Only write to indices where `ctx.active[i]` is `true`.
+    /// - Add to `forces[i]` rather than overwrite — multiple forces stack.
+    /// - Avoid reading or writing outside `0..ctx.node_count`.
+    fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]);
+}

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -18,10 +18,12 @@ use std::any::Any;
 use std::collections::HashSet;
 
 pub mod gravity;
+pub mod location_affinity;
 pub mod repulsion;
 pub mod spring_attraction;
 
 pub use gravity::Gravity;
+pub use location_affinity::LocationAffinity;
 pub use repulsion::Repulsion;
 pub use spring_attraction::SpringAttraction;
 

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -17,12 +17,14 @@ use glam::Vec2;
 use std::any::Any;
 use std::collections::HashSet;
 
+pub mod container_repulsion;
 pub mod containment;
 pub mod gravity;
 pub mod location_affinity;
 pub mod repulsion;
 pub mod spring_attraction;
 
+pub use container_repulsion::ContainerRepulsion;
 pub use containment::Containment;
 pub use gravity::Gravity;
 pub use location_affinity::LocationAffinity;

--- a/crates/layout/src/forces/mod.rs
+++ b/crates/layout/src/forces/mod.rs
@@ -15,6 +15,7 @@ use std::collections::HashSet;
 pub mod container_repulsion;
 pub mod containment;
 pub mod gravity;
+pub(crate) mod grid;
 pub mod location_affinity;
 pub mod repulsion;
 pub mod spring_attraction;

--- a/crates/layout/src/forces/repulsion.rs
+++ b/crates/layout/src/forces/repulsion.rs
@@ -1,0 +1,344 @@
+//! Grid-based Coulomb repulsion between visible nodes.
+//!
+//! Every active node pushes every other active node away with a force that
+//! falls off as `strength / dist²`. Instead of an O(N²) all-pairs loop, the
+//! force builds a spatial grid with cell size equal to the cutoff distance,
+//! then only considers the 3×3 neighbourhood of each node's cell. Pairs
+//! farther apart than the cutoff contribute zero anyway, so the grid makes
+//! the work linear in practice.
+//!
+//! On large graphs (≥ [`PARALLEL_THRESHOLD`] nodes) the per-node inner loop
+//! runs under rayon. Each iteration produces a single Vec2 into an
+//! independent output slot, so there are no write conflicts.
+
+use glam::Vec2;
+use rayon::prelude::*;
+use std::any::Any;
+use std::collections::HashMap;
+
+use super::{Force, ForceContext, PARALLEL_THRESHOLD};
+
+/// Grid-based point-Coulomb repulsion.
+///
+/// `strength`, `cutoff`, and `min_dist` map directly to the legacy
+/// [`crate::ForceParams`] fields `repulsion`, `repulsion_cutoff`, and
+/// `min_dist`.
+pub struct Repulsion {
+    /// Whether this force is currently active.
+    pub enabled: bool,
+    /// Coulomb-style repulsion coefficient applied per interacting pair.
+    pub strength: f32,
+    /// Maximum distance considered for repulsion. Pairs farther apart than
+    /// this are skipped entirely. Also sets the spatial grid cell size.
+    pub cutoff: f32,
+    /// Floor for pairwise distance to avoid `1 / dist²` blow-ups when two
+    /// nodes are nearly coincident.
+    pub min_dist: f32,
+}
+
+impl Repulsion {
+    /// Create a new repulsion force with the given parameters.
+    pub fn new(strength: f32, cutoff: f32, min_dist: f32, enabled: bool) -> Self {
+        Self {
+            enabled,
+            strength,
+            cutoff,
+            min_dist,
+        }
+    }
+}
+
+impl Force for Repulsion {
+    fn name(&self) -> &str {
+        "repulsion"
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
+        if self.strength == 0.0 || self.cutoff <= 0.0 {
+            return;
+        }
+
+        let cutoff = self.cutoff;
+        let cutoff_sq = cutoff * cutoff;
+        let inv_cutoff = 1.0 / cutoff;
+        let strength = self.strength;
+        let min_dist = self.min_dist;
+        let len = ctx.node_count;
+
+        // Cell key for every position (including hidden — indices remain
+        // stable, but hidden nodes don't get added to the grid below).
+        let cell_keys: Vec<(i32, i32)> = ctx
+            .positions
+            .iter()
+            .map(|pos| {
+                let cx = (pos.x * inv_cutoff).floor() as i32;
+                let cy = (pos.y * inv_cutoff).floor() as i32;
+                (cx, cy)
+            })
+            .collect();
+
+        // Bucket only active nodes. Hidden nodes aren't in any cell, so they
+        // can't attract force contributions from their neighbours.
+        let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::with_capacity(len / 4 + 1);
+        for (i, &key) in cell_keys.iter().enumerate() {
+            if ctx.active[i] {
+                grid.entry(key).or_default().push(i);
+            }
+        }
+
+        let positions = ctx.positions;
+        let grid_ref = &grid;
+        let active = ctx.active;
+
+        // Per-node repulsion. Each node writes into a single output slot, so
+        // the inner loop parallelises cleanly.
+        if len >= PARALLEL_THRESHOLD {
+            let contribs: Vec<Vec2> = (0..len)
+                .into_par_iter()
+                .map(|i| {
+                    if !active[i] {
+                        return Vec2::ZERO;
+                    }
+                    compute_repulsion_for_node(
+                        i, positions, grid_ref, &cell_keys, cutoff_sq, strength, min_dist,
+                    )
+                })
+                .collect();
+            for (force, contrib) in forces.iter_mut().zip(contribs.iter()) {
+                *force += *contrib;
+            }
+        } else {
+            for (i, force) in forces.iter_mut().enumerate().take(len) {
+                if !active[i] {
+                    continue;
+                }
+                *force += compute_repulsion_for_node(
+                    i, positions, grid_ref, &cell_keys, cutoff_sq, strength, min_dist,
+                );
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Compute point-based Coulomb repulsive force on node `i` from its 3×3
+/// grid neighbourhood. Center-to-center distance, no size awareness.
+#[allow(clippy::too_many_arguments)]
+fn compute_repulsion_for_node(
+    i: usize,
+    positions: &[Vec2],
+    grid: &HashMap<(i32, i32), Vec<usize>>,
+    cell_keys: &[(i32, i32)],
+    cutoff_sq: f32,
+    strength: f32,
+    min_dist: f32,
+) -> Vec2 {
+    let pos_i = positions[i];
+    let (cx, cy) = cell_keys[i];
+    let mut force = Vec2::ZERO;
+
+    // Scan 3×3 neighbourhood (including own cell).
+    for dx in -1..=1i32 {
+        for dy in -1..=1i32 {
+            let nx = cx.wrapping_add(dx);
+            let ny = cy.wrapping_add(dy);
+            if let Some(cell) = grid.get(&(nx, ny)) {
+                for &j in cell {
+                    if j == i {
+                        continue;
+                    }
+                    let delta = pos_i - positions[j];
+                    let dist_sq = delta.length_squared();
+                    if dist_sq > cutoff_sq || dist_sq < 1e-10 {
+                        continue;
+                    }
+                    let dist = dist_sq.sqrt().max(min_dist);
+                    force += delta.normalize_or_zero() * (strength / (dist * dist));
+                }
+            }
+        }
+    }
+    force
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_ir::EdgeKind;
+    use std::collections::HashSet;
+
+    fn mk_ctx<'a>(
+        positions: &'a [Vec2],
+        active: &'a [bool],
+        containers: &'a HashSet<usize>,
+        expanded: &'a HashSet<usize>,
+        toplevel: &'a HashSet<usize>,
+        children_of: &'a [Vec<usize>],
+        sizes: &'a [Vec2],
+        degrees: &'a [f32],
+        edge_pairs: &'a [(usize, usize, EdgeKind)],
+        visible_edge_kinds: &'a [EdgeKind],
+    ) -> ForceContext<'a> {
+        ForceContext {
+            positions,
+            sizes,
+            degrees,
+            active,
+            edge_pairs,
+            visible_edge_kinds,
+            children_of,
+            containers,
+            expanded,
+            toplevel_containers: toplevel,
+            node_count: positions.len(),
+        }
+    }
+
+    #[test]
+    fn disabled_strength_is_noop() {
+        let positions = vec![Vec2::new(1.0, 0.0), Vec2::new(-1.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible_edge_kinds: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &containers,
+            &expanded,
+            &toplevel,
+            &children_of,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible_edge_kinds,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        Repulsion::new(0.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn two_nodes_push_apart_symmetrically() {
+        let positions = vec![Vec2::new(5.0, 0.0), Vec2::new(-5.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible_edge_kinds: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &containers,
+            &expanded,
+            &toplevel,
+            &children_of,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible_edge_kinds,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
+        // Node 0 at +x gets pushed in +x, node 1 at -x gets pushed in -x.
+        assert!(forces[0].x > 0.0 && forces[0].y == 0.0);
+        assert!(forces[1].x < 0.0 && forces[1].y == 0.0);
+        // Newton's third law: forces are equal and opposite.
+        assert!((forces[0] + forces[1]).length() < 1e-4);
+    }
+
+    #[test]
+    fn hidden_nodes_do_not_interact() {
+        // Node 1 is hidden — it should neither push nor be pushed.
+        let positions = vec![
+            Vec2::new(1.0, 0.0),
+            Vec2::new(0.0, 0.0),
+            Vec2::new(-1.0, 0.0),
+        ];
+        let active = vec![true, false, true];
+        let sizes = vec![Vec2::ZERO; 3];
+        let degrees = vec![1.0; 3];
+        let children_of: Vec<Vec<usize>> = vec![vec![]; 3];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible_edge_kinds: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &containers,
+            &expanded,
+            &toplevel,
+            &children_of,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible_edge_kinds,
+        );
+        let mut forces = vec![Vec2::ZERO; 3];
+        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
+        assert_eq!(forces[1], Vec2::ZERO, "hidden node received force");
+        // The two visible nodes still push each other.
+        assert!(forces[0].x > 0.0);
+        assert!(forces[2].x < 0.0);
+    }
+
+    #[test]
+    fn cutoff_respected() {
+        // Two nodes far apart (farther than cutoff) should feel no force.
+        let positions = vec![Vec2::new(10000.0, 0.0), Vec2::new(-10000.0, 0.0)];
+        let active = vec![true, true];
+        let sizes = vec![Vec2::ZERO; 2];
+        let degrees = vec![1.0; 2];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
+        let visible_edge_kinds: Vec<EdgeKind> = vec![];
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &containers,
+            &expanded,
+            &toplevel,
+            &children_of,
+            &sizes,
+            &degrees,
+            &edge_pairs,
+            &visible_edge_kinds,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+}

--- a/crates/layout/src/forces/repulsion.rs
+++ b/crates/layout/src/forces/repulsion.rs
@@ -1,15 +1,15 @@
 //! Grid-based Coulomb repulsion between visible nodes.
 //!
-//! Every active node pushes every other active node away with a force that
-//! falls off as `strength / dist²`. Instead of an O(N²) all-pairs loop, the
-//! force builds a spatial grid with cell size equal to the cutoff distance,
-//! then only considers the 3×3 neighbourhood of each node's cell. Pairs
-//! farther apart than the cutoff contribute zero anyway, so the grid makes
-//! the work linear in practice.
+//! Every active node pushes every other active node away with a force
+//! that falls off as `strength / dist²`. Instead of an O(N²) all-pairs
+//! loop, a spatial grid with cell size equal to `cutoff` restricts the
+//! per-node work to a 3×3 neighbourhood. Pairs farther than `cutoff`
+//! contribute nothing anyway, so the grid makes the cost linear in
+//! practice.
 //!
-//! On large graphs (≥ [`PARALLEL_THRESHOLD`] nodes) the per-node inner loop
-//! runs under rayon. Each iteration produces a single Vec2 into an
-//! independent output slot, so there are no write conflicts.
+//! On large graphs (≥ [`PARALLEL_THRESHOLD`] nodes) the per-node inner
+//! loop runs under rayon with `par_iter_mut` directly over the output
+//! slice — each node writes one slot, so there are no write conflicts.
 
 use glam::Vec2;
 use rayon::prelude::*;
@@ -19,20 +19,16 @@ use std::collections::HashMap;
 use super::{Force, ForceContext, PARALLEL_THRESHOLD};
 
 /// Grid-based point-Coulomb repulsion.
-///
-/// `strength`, `cutoff`, and `min_dist` map directly to the legacy
-/// [`crate::ForceParams`] fields `repulsion`, `repulsion_cutoff`, and
-/// `min_dist`.
 pub struct Repulsion {
     /// Whether this force is currently active.
     pub enabled: bool,
-    /// Coulomb-style repulsion coefficient applied per interacting pair.
+    /// Coulomb-style coefficient applied per interacting pair.
     pub strength: f32,
-    /// Maximum distance considered for repulsion. Pairs farther apart than
-    /// this are skipped entirely. Also sets the spatial grid cell size.
+    /// Maximum distance considered for repulsion. Pairs farther than
+    /// this are skipped. Also sets the spatial grid cell size.
     pub cutoff: f32,
-    /// Floor for pairwise distance to avoid `1 / dist²` blow-ups when two
-    /// nodes are nearly coincident.
+    /// Floor for pairwise distance to avoid `1 / dist²` blow-ups when
+    /// two nodes are nearly coincident.
     pub min_dist: f32,
 }
 
@@ -49,10 +45,6 @@ impl Repulsion {
 }
 
 impl Force for Repulsion {
-    fn name(&self) -> &str {
-        "repulsion"
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -73,8 +65,8 @@ impl Force for Repulsion {
         let min_dist = self.min_dist;
         let len = ctx.node_count;
 
-        // Cell key for every position (including hidden — indices remain
-        // stable, but hidden nodes don't get added to the grid below).
+        // Cell key for every position. Hidden nodes get a key but aren't
+        // inserted into the grid, so they can't contribute force.
         let cell_keys: Vec<(i32, i32)> = ctx
             .positions
             .iter()
@@ -85,8 +77,6 @@ impl Force for Repulsion {
             })
             .collect();
 
-        // Bucket only active nodes. Hidden nodes aren't in any cell, so they
-        // can't attract force contributions from their neighbours.
         let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::with_capacity(len / 4 + 1);
         for (i, &key) in cell_keys.iter().enumerate() {
             if ctx.active[i] {
@@ -95,26 +85,24 @@ impl Force for Repulsion {
         }
 
         let positions = ctx.positions;
-        let grid_ref = &grid;
         let active = ctx.active;
+        let grid_ref = &grid;
 
-        // Per-node repulsion. Each node writes into a single output slot, so
-        // the inner loop parallelises cleanly.
+        // Per-node: each iteration writes a single output slot, so the
+        // work parallelises without contention.
         if len >= PARALLEL_THRESHOLD {
-            let contribs: Vec<Vec2> = (0..len)
-                .into_par_iter()
-                .map(|i| {
+            forces
+                .par_iter_mut()
+                .enumerate()
+                .take(len)
+                .for_each(|(i, force)| {
                     if !active[i] {
-                        return Vec2::ZERO;
+                        return;
                     }
-                    compute_repulsion_for_node(
+                    *force += compute_repulsion_for_node(
                         i, positions, grid_ref, &cell_keys, cutoff_sq, strength, min_dist,
-                    )
-                })
-                .collect();
-            for (force, contrib) in forces.iter_mut().zip(contribs.iter()) {
-                *force += *contrib;
-            }
+                    );
+                });
         } else {
             for (i, force) in forces.iter_mut().enumerate().take(len) {
                 if !active[i] {
@@ -136,8 +124,8 @@ impl Force for Repulsion {
     }
 }
 
-/// Compute point-based Coulomb repulsive force on node `i` from its 3×3
-/// grid neighbourhood. Center-to-center distance, no size awareness.
+/// Compute point-Coulomb repulsive force on node `i` from its 3×3 grid
+/// neighbourhood. Center-to-center distance, no size awareness.
 #[allow(clippy::too_many_arguments)]
 fn compute_repulsion_for_node(
     i: usize,
@@ -152,7 +140,6 @@ fn compute_repulsion_for_node(
     let (cx, cy) = cell_keys[i];
     let mut force = Vec2::ZERO;
 
-    // Scan 3×3 neighbourhood (including own cell).
     for dx in -1..=1i32 {
         for dy in -1..=1i32 {
             let nx = cx.wrapping_add(dx);
@@ -179,166 +166,49 @@ fn compute_repulsion_for_node(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core_ir::EdgeKind;
-    use std::collections::HashSet;
-
-    fn mk_ctx<'a>(
-        positions: &'a [Vec2],
-        active: &'a [bool],
-        containers: &'a HashSet<usize>,
-        expanded: &'a HashSet<usize>,
-        toplevel: &'a HashSet<usize>,
-        children_of: &'a [Vec<usize>],
-        sizes: &'a [Vec2],
-        degrees: &'a [f32],
-        edge_pairs: &'a [(usize, usize, EdgeKind)],
-        visible_edge_kinds: &'a [EdgeKind],
-    ) -> ForceContext<'a> {
-        ForceContext {
-            positions,
-            sizes,
-            degrees,
-            active,
-            edge_pairs,
-            visible_edge_kinds,
-            children_of,
-            containers,
-            expanded,
-            toplevel_containers: toplevel,
-            node_count: positions.len(),
-        }
-    }
+    use crate::forces::test_utils::TestCtx;
 
     #[test]
     fn disabled_strength_is_noop() {
-        let positions = vec![Vec2::new(1.0, 0.0), Vec2::new(-1.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible_edge_kinds: Vec<EdgeKind> = vec![];
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &containers,
-            &expanded,
-            &toplevel,
-            &children_of,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible_edge_kinds,
-        );
+        let tc = TestCtx::new(vec![Vec2::new(1.0, 0.0), Vec2::new(-1.0, 0.0)]);
         let mut forces = vec![Vec2::ZERO; 2];
-        Repulsion::new(0.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
+        Repulsion::new(0.0, 500.0, 1.0, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
     #[test]
     fn two_nodes_push_apart_symmetrically() {
-        let positions = vec![Vec2::new(5.0, 0.0), Vec2::new(-5.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible_edge_kinds: Vec<EdgeKind> = vec![];
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &containers,
-            &expanded,
-            &toplevel,
-            &children_of,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible_edge_kinds,
-        );
+        let tc = TestCtx::new(vec![Vec2::new(5.0, 0.0), Vec2::new(-5.0, 0.0)]);
         let mut forces = vec![Vec2::ZERO; 2];
-        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
-        // Node 0 at +x gets pushed in +x, node 1 at -x gets pushed in -x.
+        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&tc.view(), &mut forces);
+        // Node 0 at +x gets pushed in +x; node 1 at -x gets pushed in -x.
         assert!(forces[0].x > 0.0 && forces[0].y == 0.0);
         assert!(forces[1].x < 0.0 && forces[1].y == 0.0);
-        // Newton's third law: forces are equal and opposite.
+        // Newton's third law.
         assert!((forces[0] + forces[1]).length() < 1e-4);
     }
 
     #[test]
     fn hidden_nodes_do_not_interact() {
-        // Node 1 is hidden — it should neither push nor be pushed.
-        let positions = vec![
+        let mut tc = TestCtx::new(vec![
             Vec2::new(1.0, 0.0),
             Vec2::new(0.0, 0.0),
             Vec2::new(-1.0, 0.0),
-        ];
-        let active = vec![true, false, true];
-        let sizes = vec![Vec2::ZERO; 3];
-        let degrees = vec![1.0; 3];
-        let children_of: Vec<Vec<usize>> = vec![vec![]; 3];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible_edge_kinds: Vec<EdgeKind> = vec![];
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &containers,
-            &expanded,
-            &toplevel,
-            &children_of,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible_edge_kinds,
-        );
+        ]);
+        tc.active[1] = false;
         let mut forces = vec![Vec2::ZERO; 3];
-        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
+        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces[1], Vec2::ZERO, "hidden node received force");
-        // The two visible nodes still push each other.
         assert!(forces[0].x > 0.0);
         assert!(forces[2].x < 0.0);
     }
 
     #[test]
     fn cutoff_respected() {
-        // Two nodes far apart (farther than cutoff) should feel no force.
-        let positions = vec![Vec2::new(10000.0, 0.0), Vec2::new(-10000.0, 0.0)];
-        let active = vec![true, true];
-        let sizes = vec![Vec2::ZERO; 2];
-        let degrees = vec![1.0; 2];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
-        let edge_pairs: Vec<(usize, usize, EdgeKind)> = vec![];
-        let visible_edge_kinds: Vec<EdgeKind> = vec![];
-
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &containers,
-            &expanded,
-            &toplevel,
-            &children_of,
-            &sizes,
-            &degrees,
-            &edge_pairs,
-            &visible_edge_kinds,
-        );
+        // Two nodes farther apart than the cutoff should feel no force.
+        let tc = TestCtx::new(vec![Vec2::new(10000.0, 0.0), Vec2::new(-10000.0, 0.0)]);
         let mut forces = vec![Vec2::ZERO; 2];
-        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&ctx, &mut forces);
+        Repulsion::new(1000.0, 500.0, 1.0, true).apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 }

--- a/crates/layout/src/forces/repulsion.rs
+++ b/crates/layout/src/forces/repulsion.rs
@@ -64,9 +64,7 @@ impl Force for Repulsion {
         let min_dist = self.min_dist;
         let len = ctx.node_count;
 
-        // Bucket active nodes into a flat spatial grid keyed by `cutoff`.
-        // The grid falls back to a hashmap if active-node positions are
-        // pathologically spread out.
+        // Bucket active nodes into a spatial grid keyed by `cutoff`.
         let grid = SpatialGrid::build(
             cutoff,
             ctx.positions.iter().enumerate().filter_map(|(i, &pos)| {

--- a/crates/layout/src/forces/repulsion.rs
+++ b/crates/layout/src/forces/repulsion.rs
@@ -14,8 +14,8 @@
 use glam::Vec2;
 use rayon::prelude::*;
 use std::any::Any;
-use std::collections::HashMap;
 
+use super::grid::SpatialGrid;
 use super::{Force, ForceContext, PARALLEL_THRESHOLD};
 
 /// Grid-based point-Coulomb repulsion.
@@ -60,29 +60,23 @@ impl Force for Repulsion {
 
         let cutoff = self.cutoff;
         let cutoff_sq = cutoff * cutoff;
-        let inv_cutoff = 1.0 / cutoff;
         let strength = self.strength;
         let min_dist = self.min_dist;
         let len = ctx.node_count;
 
-        // Cell key for every position. Hidden nodes get a key but aren't
-        // inserted into the grid, so they can't contribute force.
-        let cell_keys: Vec<(i32, i32)> = ctx
-            .positions
-            .iter()
-            .map(|pos| {
-                let cx = (pos.x * inv_cutoff).floor() as i32;
-                let cy = (pos.y * inv_cutoff).floor() as i32;
-                (cx, cy)
-            })
-            .collect();
-
-        let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::with_capacity(len / 4 + 1);
-        for (i, &key) in cell_keys.iter().enumerate() {
-            if ctx.active[i] {
-                grid.entry(key).or_default().push(i);
-            }
-        }
+        // Bucket active nodes into a flat spatial grid keyed by `cutoff`.
+        // The grid falls back to a hashmap if active-node positions are
+        // pathologically spread out.
+        let grid = SpatialGrid::build(
+            cutoff,
+            ctx.positions.iter().enumerate().filter_map(|(i, &pos)| {
+                if ctx.active[i] {
+                    Some((i, pos))
+                } else {
+                    None
+                }
+            }),
+        );
 
         let positions = ctx.positions;
         let active = ctx.active;
@@ -100,7 +94,7 @@ impl Force for Repulsion {
                         return;
                     }
                     *force += compute_repulsion_for_node(
-                        i, positions, grid_ref, &cell_keys, cutoff_sq, strength, min_dist,
+                        i, positions, grid_ref, cutoff_sq, strength, min_dist,
                     );
                 });
         } else {
@@ -109,7 +103,7 @@ impl Force for Repulsion {
                     continue;
                 }
                 *force += compute_repulsion_for_node(
-                    i, positions, grid_ref, &cell_keys, cutoff_sq, strength, min_dist,
+                    i, positions, grid_ref, cutoff_sq, strength, min_dist,
                 );
             }
         }
@@ -124,42 +118,33 @@ impl Force for Repulsion {
     }
 }
 
-/// Compute point-Coulomb repulsive force on node `i` from its 3×3 grid
-/// neighbourhood. Center-to-center distance, no size awareness.
-#[allow(clippy::too_many_arguments)]
+/// Point-Coulomb repulsive force on node `i` from the 3×3 cell
+/// neighbourhood of its current position. Center-to-center distance,
+/// no size awareness.
 fn compute_repulsion_for_node(
     i: usize,
     positions: &[Vec2],
-    grid: &HashMap<(i32, i32), Vec<usize>>,
-    cell_keys: &[(i32, i32)],
+    grid: &SpatialGrid,
     cutoff_sq: f32,
     strength: f32,
     min_dist: f32,
 ) -> Vec2 {
     let pos_i = positions[i];
-    let (cx, cy) = cell_keys[i];
+    let query_cell = grid.cell_of(pos_i);
     let mut force = Vec2::ZERO;
 
-    for dx in -1..=1i32 {
-        for dy in -1..=1i32 {
-            let nx = cx.wrapping_add(dx);
-            let ny = cy.wrapping_add(dy);
-            if let Some(cell) = grid.get(&(nx, ny)) {
-                for &j in cell {
-                    if j == i {
-                        continue;
-                    }
-                    let delta = pos_i - positions[j];
-                    let dist_sq = delta.length_squared();
-                    if dist_sq > cutoff_sq || dist_sq < 1e-10 {
-                        continue;
-                    }
-                    let dist = dist_sq.sqrt().max(min_dist);
-                    force += delta.normalize_or_zero() * (strength / (dist * dist));
-                }
-            }
+    grid.for_each_in_neighborhood(query_cell, |j| {
+        if j == i {
+            return;
         }
-    }
+        let delta = pos_i - positions[j];
+        let dist_sq = delta.length_squared();
+        if dist_sq > cutoff_sq || dist_sq < 1e-10 {
+            return;
+        }
+        let dist = dist_sq.sqrt().max(min_dist);
+        force += delta.normalize_or_zero() * (strength / (dist * dist));
+    });
     force
 }
 

--- a/crates/layout/src/forces/spring_attraction.rs
+++ b/crates/layout/src/forces/spring_attraction.rs
@@ -1,0 +1,378 @@
+//! Edge-spring attraction force.
+//!
+//! Every visible edge acts as a linear spring between its two endpoints.
+//! The force on each endpoint is divided by `sqrt(degree)` so hub nodes
+//! with many connections don't get yanked across the canvas by the sum of
+//! all their edges. Per-edge-kind parameter overrides (`attraction` /
+//! `target_distance`) let calls and inheritance have different stiffnesses
+//! from the global fallback.
+//!
+//! On large graphs (≥ [`PARALLEL_THRESHOLD`] nodes) the per-edge loop runs
+//! under rayon. Multiple edges can touch the same endpoint, so the parallel
+//! path accumulates into per-thread local buffers and reduces at the end
+//! to avoid data races on the shared `forces` slice.
+
+use core_ir::EdgeKind;
+use glam::Vec2;
+use rayon::prelude::*;
+use std::any::Any;
+use std::collections::HashMap;
+
+use super::{Force, ForceContext, PARALLEL_THRESHOLD};
+use crate::EdgeKindParams;
+
+/// Linear-spring attraction along visible edges.
+pub struct SpringAttraction {
+    /// Whether this force is currently active.
+    pub enabled: bool,
+    /// Global spring coefficient, used when an edge's kind has no override.
+    pub global_attraction: f32,
+    /// Global rest length, used when an edge's kind has no override.
+    pub global_ideal_length: f32,
+    /// Floor for pairwise distance to avoid division-by-near-zero.
+    pub min_dist: f32,
+    /// Per-edge-kind parameter overrides.
+    pub edge_params: HashMap<EdgeKind, EdgeKindParams>,
+}
+
+impl SpringAttraction {
+    /// Create a new spring-attraction force with the given parameters.
+    pub fn new(
+        global_attraction: f32,
+        global_ideal_length: f32,
+        min_dist: f32,
+        edge_params: HashMap<EdgeKind, EdgeKindParams>,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            enabled,
+            global_attraction,
+            global_ideal_length,
+            min_dist,
+            edge_params,
+        }
+    }
+
+    /// Compute the `(attraction, rest_length)` pair for an edge kind,
+    /// falling back to the global defaults if there is no override.
+    #[inline]
+    fn params_for(&self, kind: EdgeKind) -> (f32, f32) {
+        if let Some(ep) = self.edge_params.get(&kind) {
+            (ep.attraction, ep.target_distance)
+        } else {
+            (self.global_attraction, self.global_ideal_length)
+        }
+    }
+}
+
+impl Force for SpringAttraction {
+    fn name(&self) -> &str {
+        "spring_attraction"
+    }
+
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
+        if ctx.edge_pairs.is_empty() {
+            return;
+        }
+        let len = ctx.node_count;
+
+        if len >= PARALLEL_THRESHOLD {
+            // Parallel path: each rayon worker accumulates into its own
+            // thread-local buffer, then we reduce the buffers together.
+            // This avoids data races on the shared `forces` slice caused by
+            // multiple edges touching the same endpoint.
+            let local_forces: Vec<Vec2> = ctx
+                .edge_pairs
+                .par_iter()
+                .fold(
+                    || vec![Vec2::ZERO; len],
+                    |mut local, &(from, to, kind)| {
+                        self.accumulate_edge(ctx, &mut local, from, to, kind);
+                        local
+                    },
+                )
+                .reduce(
+                    || vec![Vec2::ZERO; len],
+                    |mut acc, partial| {
+                        for (a, b) in acc.iter_mut().zip(partial.iter()) {
+                            *a += *b;
+                        }
+                        acc
+                    },
+                );
+            for (force, contrib) in forces.iter_mut().zip(local_forces.iter()) {
+                *force += *contrib;
+            }
+        } else {
+            // Serial path: write directly into `forces`.
+            for &(from, to, kind) in ctx.edge_pairs {
+                self.accumulate_edge(ctx, forces, from, to, kind);
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl SpringAttraction {
+    /// Accumulate one edge's spring contribution into `forces`.
+    /// Shared between the serial and parallel paths so the per-edge math
+    /// is guaranteed identical.
+    #[inline]
+    fn accumulate_edge(
+        &self,
+        ctx: &ForceContext,
+        forces: &mut [Vec2],
+        from: usize,
+        to: usize,
+        kind: EdgeKind,
+    ) {
+        // Edge-kind filter: only edges the UI is rendering exert a force.
+        if !ctx.visible_edge_kinds.contains(&kind) {
+            return;
+        }
+        // Hidden endpoints don't participate.
+        if !ctx.active[from] || !ctx.active[to] {
+            return;
+        }
+
+        let (attr, rest_len) = self.params_for(kind);
+        let delta = ctx.positions[to] - ctx.positions[from];
+        let dist = delta.length().max(self.min_dist);
+        let displacement = attr * (dist - rest_len);
+        let dir = delta.normalize_or_zero();
+        // Scale by 1/sqrt(degree) at each endpoint so hubs stay calm.
+        forces[from] += dir * displacement / ctx.degrees[from].sqrt();
+        forces[to] -= dir * displacement / ctx.degrees[to].sqrt();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn mk_ctx<'a>(
+        positions: &'a [Vec2],
+        active: &'a [bool],
+        edge_pairs: &'a [(usize, usize, EdgeKind)],
+        visible_edge_kinds: &'a [EdgeKind],
+        degrees: &'a [f32],
+        sizes: &'a [Vec2],
+        children_of: &'a [Vec<usize>],
+        containers: &'a HashSet<usize>,
+        expanded: &'a HashSet<usize>,
+        toplevel: &'a HashSet<usize>,
+    ) -> ForceContext<'a> {
+        ForceContext {
+            positions,
+            sizes,
+            degrees,
+            active,
+            edge_pairs,
+            visible_edge_kinds,
+            children_of,
+            containers,
+            expanded,
+            toplevel_containers: toplevel,
+            node_count: positions.len(),
+        }
+    }
+
+    fn empty_edge_params() -> HashMap<EdgeKind, EdgeKindParams> {
+        HashMap::new()
+    }
+
+    #[test]
+    fn long_edge_pulls_endpoints_together() {
+        // Two nodes 100 units apart with a rest length of 10: the spring
+        // should pull them toward each other.
+        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
+        let active = vec![true, true];
+        let degrees = vec![1.0; 2];
+        let sizes = vec![Vec2::ZERO; 2];
+        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
+        let visible = vec![EdgeKind::Calls];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &edge_pairs,
+            &visible,
+            &degrees,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+
+        // Node 0 (at -50) is pulled toward +x; node 1 (at +50) toward -x.
+        assert!(forces[0].x > 0.0);
+        assert!(forces[1].x < 0.0);
+        // Newton's third law.
+        assert!((forces[0] + forces[1]).length() < 1e-4);
+    }
+
+    #[test]
+    fn short_edge_pushes_endpoints_apart() {
+        // Two nodes only 2 units apart with a rest length of 20: spring
+        // should push them away from each other.
+        let positions = vec![Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)];
+        let active = vec![true, true];
+        let degrees = vec![1.0; 2];
+        let sizes = vec![Vec2::ZERO; 2];
+        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
+        let visible = vec![EdgeKind::Calls];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &edge_pairs,
+            &visible,
+            &degrees,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        SpringAttraction::new(0.1, 20.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+
+        // Node 0 at -1 pushed further in -x; node 1 at +1 pushed in +x.
+        assert!(forces[0].x < 0.0);
+        assert!(forces[1].x > 0.0);
+    }
+
+    #[test]
+    fn invisible_edge_kind_is_skipped() {
+        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
+        let active = vec![true, true];
+        let degrees = vec![1.0; 2];
+        let sizes = vec![Vec2::ZERO; 2];
+        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
+        // `Calls` is NOT in the visible list — the edge should be ignored.
+        let visible = vec![EdgeKind::Inherits];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &edge_pairs,
+            &visible,
+            &degrees,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn hidden_endpoint_skips_edge() {
+        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
+        // Node 1 is hidden.
+        let active = vec![true, false];
+        let degrees = vec![1.0; 2];
+        let sizes = vec![Vec2::ZERO; 2];
+        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
+        let visible = vec![EdgeKind::Calls];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &edge_pairs,
+            &visible,
+            &degrees,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+        assert_eq!(forces, vec![Vec2::ZERO; 2]);
+    }
+
+    #[test]
+    fn edge_kind_override_takes_precedence() {
+        // Global params would give zero force (rest_len equals distance).
+        // Per-kind override changes the rest length so the spring pulls.
+        let positions = vec![Vec2::new(0.0, 0.0), Vec2::new(10.0, 0.0)];
+        let active = vec![true, true];
+        let degrees = vec![1.0; 2];
+        let sizes = vec![Vec2::ZERO; 2];
+        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Inherits)];
+        let visible = vec![EdgeKind::Inherits];
+        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
+        let containers = HashSet::new();
+        let expanded = HashSet::new();
+        let toplevel = HashSet::new();
+
+        let mut edge_params = HashMap::new();
+        edge_params.insert(
+            EdgeKind::Inherits,
+            EdgeKindParams {
+                target_distance: 2.0,
+                attraction: 0.5,
+            },
+        );
+
+        let ctx = mk_ctx(
+            &positions,
+            &active,
+            &edge_pairs,
+            &visible,
+            &degrees,
+            &sizes,
+            &children_of,
+            &containers,
+            &expanded,
+            &toplevel,
+        );
+        let mut forces = vec![Vec2::ZERO; 2];
+        // Global rest length = 10, matching the actual distance, so the
+        // global params would produce zero force. The Inherits override
+        // should pull the endpoints together.
+        SpringAttraction::new(0.1, 10.0, 1.0, edge_params, true).apply(&ctx, &mut forces);
+        assert!(forces[0].x > 0.0);
+        assert!(forces[1].x < 0.0);
+    }
+}

--- a/crates/layout/src/forces/spring_attraction.rs
+++ b/crates/layout/src/forces/spring_attraction.rs
@@ -1,16 +1,16 @@
 //! Edge-spring attraction force.
 //!
 //! Every visible edge acts as a linear spring between its two endpoints.
-//! The force on each endpoint is divided by `sqrt(degree)` so hub nodes
-//! with many connections don't get yanked across the canvas by the sum of
+//! Each endpoint's force is divided by `sqrt(degree)` so hub nodes with
+//! many connections don't get yanked across the canvas by the sum of
 //! all their edges. Per-edge-kind parameter overrides (`attraction` /
-//! `target_distance`) let calls and inheritance have different stiffnesses
-//! from the global fallback.
+//! `target_distance`) let call and inheritance edges have different
+//! stiffnesses from the global fallback.
 //!
-//! On large graphs (≥ [`PARALLEL_THRESHOLD`] nodes) the per-edge loop runs
-//! under rayon. Multiple edges can touch the same endpoint, so the parallel
-//! path accumulates into per-thread local buffers and reduces at the end
-//! to avoid data races on the shared `forces` slice.
+//! On large graphs (≥ [`PARALLEL_THRESHOLD`] nodes) the per-edge loop
+//! runs under rayon. Multiple edges can touch the same endpoint, so the
+//! parallel path accumulates into per-thread local buffers and reduces
+//! them at the end to avoid data races on the shared `forces` slice.
 
 use core_ir::EdgeKind;
 use glam::Vec2;
@@ -53,8 +53,8 @@ impl SpringAttraction {
         }
     }
 
-    /// Compute the `(attraction, rest_length)` pair for an edge kind,
-    /// falling back to the global defaults if there is no override.
+    /// `(attraction, rest_length)` for an edge kind, falling back to the
+    /// global defaults when no override exists.
     #[inline]
     fn params_for(&self, kind: EdgeKind) -> (f32, f32) {
         if let Some(ep) = self.edge_params.get(&kind) {
@@ -63,13 +63,38 @@ impl SpringAttraction {
             (self.global_attraction, self.global_ideal_length)
         }
     }
+
+    /// Accumulate one edge's spring contribution into `forces`. Shared
+    /// between the serial and parallel paths so the per-edge math stays
+    /// identical.
+    #[inline]
+    fn accumulate_edge(
+        &self,
+        ctx: &ForceContext,
+        forces: &mut [Vec2],
+        from: usize,
+        to: usize,
+        kind: EdgeKind,
+    ) {
+        if !ctx.visible_edge_kinds.contains(&kind) {
+            return;
+        }
+        if !ctx.active[from] || !ctx.active[to] {
+            return;
+        }
+
+        let (attr, rest_len) = self.params_for(kind);
+        let delta = ctx.positions[to] - ctx.positions[from];
+        let dist = delta.length().max(self.min_dist);
+        let displacement = attr * (dist - rest_len);
+        let dir = delta.normalize_or_zero();
+        // Scale by 1/sqrt(degree) at each endpoint so hubs stay calm.
+        forces[from] += dir * displacement / ctx.degrees[from].sqrt();
+        forces[to] -= dir * displacement / ctx.degrees[to].sqrt();
+    }
 }
 
 impl Force for SpringAttraction {
-    fn name(&self) -> &str {
-        "spring_attraction"
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -85,10 +110,9 @@ impl Force for SpringAttraction {
         let len = ctx.node_count;
 
         if len >= PARALLEL_THRESHOLD {
-            // Parallel path: each rayon worker accumulates into its own
-            // thread-local buffer, then we reduce the buffers together.
-            // This avoids data races on the shared `forces` slice caused by
-            // multiple edges touching the same endpoint.
+            // Multiple edges can touch the same endpoint, so each worker
+            // accumulates into a thread-local buffer and reduces at the
+            // end to avoid data races on `forces`.
             let local_forces: Vec<Vec2> = ctx
                 .edge_pairs
                 .par_iter()
@@ -112,7 +136,6 @@ impl Force for SpringAttraction {
                 *force += *contrib;
             }
         } else {
-            // Serial path: write directly into `forces`.
             for &(from, to, kind) in ctx.edge_pairs {
                 self.accumulate_edge(ctx, forces, from, to, kind);
             }
@@ -128,70 +151,10 @@ impl Force for SpringAttraction {
     }
 }
 
-impl SpringAttraction {
-    /// Accumulate one edge's spring contribution into `forces`.
-    /// Shared between the serial and parallel paths so the per-edge math
-    /// is guaranteed identical.
-    #[inline]
-    fn accumulate_edge(
-        &self,
-        ctx: &ForceContext,
-        forces: &mut [Vec2],
-        from: usize,
-        to: usize,
-        kind: EdgeKind,
-    ) {
-        // Edge-kind filter: only edges the UI is rendering exert a force.
-        if !ctx.visible_edge_kinds.contains(&kind) {
-            return;
-        }
-        // Hidden endpoints don't participate.
-        if !ctx.active[from] || !ctx.active[to] {
-            return;
-        }
-
-        let (attr, rest_len) = self.params_for(kind);
-        let delta = ctx.positions[to] - ctx.positions[from];
-        let dist = delta.length().max(self.min_dist);
-        let displacement = attr * (dist - rest_len);
-        let dir = delta.normalize_or_zero();
-        // Scale by 1/sqrt(degree) at each endpoint so hubs stay calm.
-        forces[from] += dir * displacement / ctx.degrees[from].sqrt();
-        forces[to] -= dir * displacement / ctx.degrees[to].sqrt();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
-
-    fn mk_ctx<'a>(
-        positions: &'a [Vec2],
-        active: &'a [bool],
-        edge_pairs: &'a [(usize, usize, EdgeKind)],
-        visible_edge_kinds: &'a [EdgeKind],
-        degrees: &'a [f32],
-        sizes: &'a [Vec2],
-        children_of: &'a [Vec<usize>],
-        containers: &'a HashSet<usize>,
-        expanded: &'a HashSet<usize>,
-        toplevel: &'a HashSet<usize>,
-    ) -> ForceContext<'a> {
-        ForceContext {
-            positions,
-            sizes,
-            degrees,
-            active,
-            edge_pairs,
-            visible_edge_kinds,
-            children_of,
-            containers,
-            expanded,
-            toplevel_containers: toplevel,
-            node_count: positions.len(),
-        }
-    }
+    use crate::forces::test_utils::TestCtx;
 
     fn empty_edge_params() -> HashMap<EdgeKind, EdgeKindParams> {
         HashMap::new()
@@ -201,150 +164,68 @@ mod tests {
     fn long_edge_pulls_endpoints_together() {
         // Two nodes 100 units apart with a rest length of 10: the spring
         // should pull them toward each other.
-        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
-        let active = vec![true, true];
-        let degrees = vec![1.0; 2];
-        let sizes = vec![Vec2::ZERO; 2];
-        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
-        let visible = vec![EdgeKind::Calls];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
+        let mut tc = TestCtx::new(vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)]);
+        tc.edge_pairs.push((0, 1, EdgeKind::Calls));
+        tc.visible_edge_kinds.push(EdgeKind::Calls);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &edge_pairs,
-            &visible,
-            &degrees,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true)
+            .apply(&tc.view(), &mut forces);
 
-        // Node 0 (at -50) is pulled toward +x; node 1 (at +50) toward -x.
         assert!(forces[0].x > 0.0);
         assert!(forces[1].x < 0.0);
-        // Newton's third law.
         assert!((forces[0] + forces[1]).length() < 1e-4);
     }
 
     #[test]
     fn short_edge_pushes_endpoints_apart() {
-        // Two nodes only 2 units apart with a rest length of 20: spring
+        // Two nodes 2 units apart with a rest length of 20: the spring
         // should push them away from each other.
-        let positions = vec![Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)];
-        let active = vec![true, true];
-        let degrees = vec![1.0; 2];
-        let sizes = vec![Vec2::ZERO; 2];
-        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
-        let visible = vec![EdgeKind::Calls];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
+        let mut tc = TestCtx::new(vec![Vec2::new(-1.0, 0.0), Vec2::new(1.0, 0.0)]);
+        tc.edge_pairs.push((0, 1, EdgeKind::Calls));
+        tc.visible_edge_kinds.push(EdgeKind::Calls);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &edge_pairs,
-            &visible,
-            &degrees,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        SpringAttraction::new(0.1, 20.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+        SpringAttraction::new(0.1, 20.0, 1.0, empty_edge_params(), true)
+            .apply(&tc.view(), &mut forces);
 
-        // Node 0 at -1 pushed further in -x; node 1 at +1 pushed in +x.
         assert!(forces[0].x < 0.0);
         assert!(forces[1].x > 0.0);
     }
 
     #[test]
     fn invisible_edge_kind_is_skipped() {
-        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
-        let active = vec![true, true];
-        let degrees = vec![1.0; 2];
-        let sizes = vec![Vec2::ZERO; 2];
-        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
+        let mut tc = TestCtx::new(vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)]);
+        tc.edge_pairs.push((0, 1, EdgeKind::Calls));
         // `Calls` is NOT in the visible list — the edge should be ignored.
-        let visible = vec![EdgeKind::Inherits];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
+        tc.visible_edge_kinds.push(EdgeKind::Inherits);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &edge_pairs,
-            &visible,
-            &degrees,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true)
+            .apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
     #[test]
     fn hidden_endpoint_skips_edge() {
-        let positions = vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)];
-        // Node 1 is hidden.
-        let active = vec![true, false];
-        let degrees = vec![1.0; 2];
-        let sizes = vec![Vec2::ZERO; 2];
-        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Calls)];
-        let visible = vec![EdgeKind::Calls];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
+        let mut tc = TestCtx::new(vec![Vec2::new(-50.0, 0.0), Vec2::new(50.0, 0.0)]);
+        tc.active[1] = false;
+        tc.edge_pairs.push((0, 1, EdgeKind::Calls));
+        tc.visible_edge_kinds.push(EdgeKind::Calls);
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &edge_pairs,
-            &visible,
-            &degrees,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true).apply(&ctx, &mut forces);
+        SpringAttraction::new(0.1, 10.0, 1.0, empty_edge_params(), true)
+            .apply(&tc.view(), &mut forces);
         assert_eq!(forces, vec![Vec2::ZERO; 2]);
     }
 
     #[test]
     fn edge_kind_override_takes_precedence() {
         // Global params would give zero force (rest_len equals distance).
-        // Per-kind override changes the rest length so the spring pulls.
-        let positions = vec![Vec2::new(0.0, 0.0), Vec2::new(10.0, 0.0)];
-        let active = vec![true, true];
-        let degrees = vec![1.0; 2];
-        let sizes = vec![Vec2::ZERO; 2];
-        let edge_pairs = vec![(0usize, 1usize, EdgeKind::Inherits)];
-        let visible = vec![EdgeKind::Inherits];
-        let children_of: Vec<Vec<usize>> = vec![vec![], vec![]];
-        let containers = HashSet::new();
-        let expanded = HashSet::new();
-        let toplevel = HashSet::new();
+        // The per-kind override changes the rest length so the spring pulls.
+        let mut tc = TestCtx::new(vec![Vec2::new(0.0, 0.0), Vec2::new(10.0, 0.0)]);
+        tc.edge_pairs.push((0, 1, EdgeKind::Inherits));
+        tc.visible_edge_kinds.push(EdgeKind::Inherits);
 
         let mut edge_params = HashMap::new();
         edge_params.insert(
@@ -355,23 +236,8 @@ mod tests {
             },
         );
 
-        let ctx = mk_ctx(
-            &positions,
-            &active,
-            &edge_pairs,
-            &visible,
-            &degrees,
-            &sizes,
-            &children_of,
-            &containers,
-            &expanded,
-            &toplevel,
-        );
         let mut forces = vec![Vec2::ZERO; 2];
-        // Global rest length = 10, matching the actual distance, so the
-        // global params would produce zero force. The Inherits override
-        // should pull the endpoints together.
-        SpringAttraction::new(0.1, 10.0, 1.0, edge_params, true).apply(&ctx, &mut forces);
+        SpringAttraction::new(0.1, 10.0, 1.0, edge_params, true).apply(&tc.view(), &mut forces);
         assert!(forces[0].x > 0.0);
         assert!(forces[1].x < 0.0);
     }

--- a/crates/layout/src/forces/spring_attraction.rs
+++ b/crates/layout/src/forces/spring_attraction.rs
@@ -7,18 +7,18 @@
 //! `target_distance`) let call and inheritance edges have different
 //! stiffnesses from the global fallback.
 //!
-//! On large graphs (≥ [`PARALLEL_THRESHOLD`] nodes) the per-edge loop
-//! runs under rayon. Multiple edges can touch the same endpoint, so the
-//! parallel path accumulates into per-thread local buffers and reduces
-//! them at the end to avoid data races on the shared `forces` slice.
+//! The edge loop is serial and writes directly into the shared `forces`
+//! accumulator. Per-edge work is tiny, so even on large graphs the
+//! single-threaded cost is a few milliseconds — well under the point
+//! where rayon's task-spawn + per-thread buffer allocation overhead
+//! starts paying off.
 
 use core_ir::EdgeKind;
 use glam::Vec2;
-use rayon::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
 
-use super::{Force, ForceContext, PARALLEL_THRESHOLD};
+use super::{Force, ForceContext};
 use crate::EdgeKindParams;
 
 /// Linear-spring attraction along visible edges.
@@ -104,41 +104,16 @@ impl Force for SpringAttraction {
     }
 
     fn apply(&self, ctx: &ForceContext, forces: &mut [Vec2]) {
-        if ctx.edge_pairs.is_empty() {
-            return;
-        }
-        let len = ctx.node_count;
-
-        if len >= PARALLEL_THRESHOLD {
-            // Multiple edges can touch the same endpoint, so each worker
-            // accumulates into a thread-local buffer and reduces at the
-            // end to avoid data races on `forces`.
-            let local_forces: Vec<Vec2> = ctx
-                .edge_pairs
-                .par_iter()
-                .fold(
-                    || vec![Vec2::ZERO; len],
-                    |mut local, &(from, to, kind)| {
-                        self.accumulate_edge(ctx, &mut local, from, to, kind);
-                        local
-                    },
-                )
-                .reduce(
-                    || vec![Vec2::ZERO; len],
-                    |mut acc, partial| {
-                        for (a, b) in acc.iter_mut().zip(partial.iter()) {
-                            *a += *b;
-                        }
-                        acc
-                    },
-                );
-            for (force, contrib) in forces.iter_mut().zip(local_forces.iter()) {
-                *force += *contrib;
-            }
-        } else {
-            for &(from, to, kind) in ctx.edge_pairs {
-                self.accumulate_edge(ctx, forces, from, to, kind);
-            }
+        // Serial single-pass accumulation into the shared `forces`
+        // slice. Per-edge work is tiny (~50-100 ns), so even at 200k
+        // edges this is <20 ms single-thread — well below the point
+        // where rayon's task-spawn + per-thread buffer allocation
+        // starts paying off. The previous `par_iter().fold(|| vec![...])`
+        // path allocated one N-sized `Vec<Vec2>` per rayon chunk, which
+        // at 57k nodes × ~16 chunks was ~16 MB of allocator churn per
+        // step.
+        for &(from, to, kind) in ctx.edge_pairs {
+            self.accumulate_edge(ctx, forces, from, to, kind);
         }
     }
 

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -422,6 +422,22 @@ impl LayoutState {
         }
     }
 
+    /// Borrow the pipeline force of type `T`, if present. Each force
+    /// type is unique in the pipeline, so the result effectively
+    /// identifies "the" force of that type.
+    pub fn force<T: forces::Force>(&self) -> Option<&T> {
+        self.forces
+            .iter()
+            .find_map(|f| f.as_any().downcast_ref::<T>())
+    }
+
+    /// Mutably borrow the pipeline force of type `T`, if present.
+    pub fn force_mut<T: forces::Force>(&mut self) -> Option<&mut T> {
+        self.forces
+            .iter_mut()
+            .find_map(|f| f.as_any_mut().downcast_mut::<T>())
+    }
+
     /// Copy parameter values from [`ForceParams`] into each pipeline
     /// force. Runs once per `step_inner` call so UI-driven param edits
     /// take effect immediately without plumbing a setter per field.

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -235,9 +235,7 @@ pub struct LayoutState {
     /// Per-node visibility flag. `active[i] == true` means node `i`
     /// participates in the simulation this step. Rebuilt from
     /// [`Self::collapse_hidden`] and [`Self::external_hidden`] by
-    /// [`Self::rebuild_active`]. Kept as a dense `Vec<bool>` so the hot
-    /// path can test visibility with an array lookup instead of a
-    /// `HashSet::contains` call (§1 of issue #33).
+    /// [`Self::rebuild_active`].
     active: Vec<bool>,
     /// Maps each node index to its parent container index (via Contains edges).
     parent_of: Vec<Option<usize>>,
@@ -260,9 +258,9 @@ pub struct LayoutState {
     /// Per-node bounding box sizes in world units. Used for size-aware
     /// repulsion (edge-to-edge distance instead of center-to-center).
     sizes: Vec<Vec2>,
-    /// Composable force pipeline. Forces are progressively extracted out of
-    /// `step_inner` into this list (see issue #33). On each step, every
-    /// enabled force accumulates contributions into the shared force buffer.
+    /// Composable force pipeline run each step. Every enabled force
+    /// accumulates contributions into a shared buffer that is then
+    /// integrated into velocities and positions.
     forces: Vec<Box<dyn forces::Force>>,
 }
 
@@ -366,11 +364,6 @@ impl LayoutState {
         let external_hidden = vec![false; n];
         let active = vec![true; n];
 
-        // Build the force pipeline. Forces are progressively extracted out
-        // of the inline code in `step_inner` (see issue #33). Each force
-        // carries its own enabled flag and tunable parameters, kept in sync
-        // with `ForceParams` via `sync_forces_from_params` until Phase 3
-        // removes the facade entirely.
         let force_pipeline: Vec<Box<dyn forces::Force>> = vec![
             Box::new(forces::Repulsion::new(
                 params.repulsion,
@@ -428,69 +421,47 @@ impl LayoutState {
         }
     }
 
-    /// Copy parameter values from the legacy [`ForceParams`] struct into
-    /// each extracted force. This keeps the existing `params_mut()` /
-    /// settings-load flow working while forces are progressively extracted.
-    /// Phase 3 of issue #33 will replace it with `export_params` /
-    /// `import_params` and remove `ForceParams` from `LayoutState`.
+    /// Copy parameter values from [`ForceParams`] into each pipeline
+    /// force. Runs once per `step_inner` call so UI-driven param edits
+    /// take effect immediately without plumbing a setter per field.
     fn sync_forces_from_params(&mut self) {
-        // Snapshot relevant scalars first — we can't hold `&self.params`
-        // while also mutably iterating `self.forces`. `edge_params` is
-        // cloned because `SpringAttraction` owns its own copy.
-        let gravity_strength = self.params.gravity;
-        let gravity_enabled = self.params.gravity_enabled;
-        let repulsion_strength = self.params.repulsion;
-        let repulsion_cutoff = self.params.repulsion_cutoff;
-        let repulsion_min_dist = self.params.min_dist;
-        let repulsion_enabled = self.params.repulsion_enabled;
-        let attraction_strength = self.params.attraction;
-        let attraction_ideal_length = self.params.ideal_length;
-        let attraction_min_dist = self.params.min_dist;
-        let attraction_enabled = self.params.attraction_enabled;
-        let attraction_edge_params = self.params.edge_params.clone();
-        let location_strength = self.params.location_strength;
-        let location_falloff = self.params.location_falloff;
-        let location_enabled = self.params.location_enabled;
-        let containment_strength = self.params.containment_strength;
-        let containment_enabled = self.params.containment_enabled;
-        let container_repulsion_strength = self.params.container_repulsion;
-        let container_repulsion_enabled = self.params.container_repulsion_enabled;
+        let p = self.params.clone();
         for force in self.forces.iter_mut() {
             let any = force.as_any_mut();
             if let Some(g) = any.downcast_mut::<forces::Gravity>() {
-                g.strength = gravity_strength;
-                g.enabled = gravity_enabled;
+                g.strength = p.gravity;
+                g.enabled = p.gravity_enabled;
                 continue;
             }
             if let Some(r) = any.downcast_mut::<forces::Repulsion>() {
-                r.strength = repulsion_strength;
-                r.cutoff = repulsion_cutoff;
-                r.min_dist = repulsion_min_dist;
-                r.enabled = repulsion_enabled;
+                r.strength = p.repulsion;
+                r.cutoff = p.repulsion_cutoff;
+                r.min_dist = p.min_dist;
+                r.enabled = p.repulsion_enabled;
                 continue;
             }
             if let Some(s) = any.downcast_mut::<forces::SpringAttraction>() {
-                s.global_attraction = attraction_strength;
-                s.global_ideal_length = attraction_ideal_length;
-                s.min_dist = attraction_min_dist;
-                s.enabled = attraction_enabled;
-                s.edge_params = attraction_edge_params.clone();
+                s.global_attraction = p.attraction;
+                s.global_ideal_length = p.ideal_length;
+                s.min_dist = p.min_dist;
+                s.enabled = p.attraction_enabled;
+                s.edge_params.clone_from(&p.edge_params);
                 continue;
             }
             if let Some(l) = any.downcast_mut::<forces::LocationAffinity>() {
-                l.strength = location_strength;
-                l.falloff = location_falloff;
-                l.enabled = location_enabled;
+                l.strength = p.location_strength;
+                l.falloff = p.location_falloff;
+                l.enabled = p.location_enabled;
                 continue;
             }
             if let Some(c) = any.downcast_mut::<forces::Containment>() {
-                c.strength = containment_strength;
-                c.enabled = containment_enabled;
+                c.strength = p.containment_strength;
+                c.enabled = p.containment_enabled;
                 continue;
             }
             if let Some(cr) = any.downcast_mut::<forces::ContainerRepulsion>() {
-                cr.strength = container_repulsion_strength;
-                cr.enabled = container_repulsion_enabled;
+                cr.strength = p.container_repulsion;
+                cr.enabled = p.container_repulsion_enabled;
                 continue;
             }
         }
@@ -528,8 +499,6 @@ impl LayoutState {
             return;
         }
 
-        // Push the latest tunable values from `self.params` into the
-        // force pipeline once per call.
         self.sync_forces_from_params();
 
         for _ in 0..n {

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -227,7 +227,11 @@ pub struct LayoutState {
     visible_edge_kinds: Vec<EdgeKind>,
     id_to_idx: IndexMap<SymbolId, usize>,
     pins: IndexMap<SymbolId, Vec2>,
-    params: ForceParams,
+    /// Velocity damping factor applied each step (lower = more damping).
+    pub damping: f32,
+    /// Maximum velocity magnitude per node per step. Prevents wild
+    /// overshooting when forces are large.
+    pub max_velocity: f32,
     /// Per-node edge degree (number of edges touching this node).
     /// Used to normalize spring forces on high-degree hubs.
     degrees: Vec<f32>,
@@ -406,7 +410,8 @@ impl LayoutState {
             visible_edge_kinds,
             id_to_idx,
             pins: IndexMap::new(),
-            params,
+            damping: params.damping,
+            max_velocity: params.max_velocity,
             degrees,
             total_steps: 0,
             active,
@@ -439,60 +444,89 @@ impl LayoutState {
     }
 
     /// Snapshot the current tunable parameters into a [`ForceParams`]
-    /// struct for serialization to `spaghetti_settings.json`.
+    /// struct for serialization to `spaghetti_settings.json`. Reads
+    /// each value from its canonical home: integration params come from
+    /// `self`, force-specific params come from the pipeline entries.
     pub fn export_params(&self) -> ForceParams {
-        self.params.clone()
+        let mut out = ForceParams {
+            damping: self.damping,
+            max_velocity: self.max_velocity,
+            ..ForceParams::default()
+        };
+        if let Some(r) = self.force::<forces::Repulsion>() {
+            out.repulsion = r.strength;
+            out.repulsion_cutoff = r.cutoff;
+            out.min_dist = r.min_dist;
+            out.repulsion_enabled = r.enabled;
+        }
+        if let Some(s) = self.force::<forces::SpringAttraction>() {
+            out.attraction = s.global_attraction;
+            out.ideal_length = s.global_ideal_length;
+            out.attraction_enabled = s.enabled;
+            out.edge_params.clone_from(&s.edge_params);
+        }
+        if let Some(g) = self.force::<forces::Gravity>() {
+            out.gravity = g.strength;
+            out.gravity_enabled = g.enabled;
+        }
+        if let Some(l) = self.force::<forces::LocationAffinity>() {
+            out.location_strength = l.strength;
+            out.location_falloff = l.falloff;
+            out.location_enabled = l.enabled;
+        }
+        if let Some(c) = self.force::<forces::Containment>() {
+            out.containment_strength = c.strength;
+            out.containment_enabled = c.enabled;
+        }
+        if let Some(cr) = self.force::<forces::ContainerRepulsion>() {
+            out.container_repulsion = cr.strength;
+            out.container_repulsion_enabled = cr.enabled;
+        }
+        out
     }
 
-    /// Apply a [`ForceParams`] snapshot to the simulation. Individual
-    /// force params are propagated into the pipeline on the next
-    /// [`step`](Self::step) via the same sync mechanism `params_mut`
-    /// already uses.
+    /// Apply a [`ForceParams`] snapshot to the simulation, writing
+    /// each value directly into its canonical home (integration params
+    /// on `self`, force params on the pipeline entries).
     pub fn import_params(&mut self, params: &ForceParams) {
-        self.params = params.clone();
-    }
-
-    /// Copy parameter values from [`ForceParams`] into each pipeline
-    /// force. Runs once per `step_inner` call so UI-driven param edits
-    /// take effect immediately without plumbing a setter per field.
-    fn sync_forces_from_params(&mut self) {
-        let p = self.params.clone();
+        self.damping = params.damping;
+        self.max_velocity = params.max_velocity;
         for force in self.forces.iter_mut() {
             let any = force.as_any_mut();
             if let Some(g) = any.downcast_mut::<forces::Gravity>() {
-                g.strength = p.gravity;
-                g.enabled = p.gravity_enabled;
+                g.strength = params.gravity;
+                g.enabled = params.gravity_enabled;
                 continue;
             }
             if let Some(r) = any.downcast_mut::<forces::Repulsion>() {
-                r.strength = p.repulsion;
-                r.cutoff = p.repulsion_cutoff;
-                r.min_dist = p.min_dist;
-                r.enabled = p.repulsion_enabled;
+                r.strength = params.repulsion;
+                r.cutoff = params.repulsion_cutoff;
+                r.min_dist = params.min_dist;
+                r.enabled = params.repulsion_enabled;
                 continue;
             }
             if let Some(s) = any.downcast_mut::<forces::SpringAttraction>() {
-                s.global_attraction = p.attraction;
-                s.global_ideal_length = p.ideal_length;
-                s.min_dist = p.min_dist;
-                s.enabled = p.attraction_enabled;
-                s.edge_params.clone_from(&p.edge_params);
+                s.global_attraction = params.attraction;
+                s.global_ideal_length = params.ideal_length;
+                s.min_dist = params.min_dist;
+                s.enabled = params.attraction_enabled;
+                s.edge_params.clone_from(&params.edge_params);
                 continue;
             }
             if let Some(l) = any.downcast_mut::<forces::LocationAffinity>() {
-                l.strength = p.location_strength;
-                l.falloff = p.location_falloff;
-                l.enabled = p.location_enabled;
+                l.strength = params.location_strength;
+                l.falloff = params.location_falloff;
+                l.enabled = params.location_enabled;
                 continue;
             }
             if let Some(c) = any.downcast_mut::<forces::Containment>() {
-                c.strength = p.containment_strength;
-                c.enabled = p.containment_enabled;
+                c.strength = params.containment_strength;
+                c.enabled = params.containment_enabled;
                 continue;
             }
             if let Some(cr) = any.downcast_mut::<forces::ContainerRepulsion>() {
-                cr.strength = p.container_repulsion;
-                cr.enabled = p.container_repulsion_enabled;
+                cr.strength = params.container_repulsion;
+                cr.enabled = params.container_repulsion_enabled;
                 continue;
             }
         }
@@ -529,8 +563,6 @@ impl LayoutState {
         if len == 0 {
             return;
         }
-
-        self.sync_forces_from_params();
 
         for _ in 0..n {
             if early_stop && self.energy() < EARLY_STOP_ENERGY {
@@ -576,9 +608,9 @@ impl LayoutState {
     /// slot, so the work parallelises without contention.
     fn integrate(&mut self, forces: &[Vec2]) {
         let cooling = (1.0 - (self.total_steps as f32 / 300.0).min(0.95)).max(0.05);
-        let effective_damping = self.params.damping * cooling;
-        let max_vel = self.params.max_velocity * cooling;
-        let max_force = self.params.max_velocity * 2.0;
+        let effective_damping = self.damping * cooling;
+        let max_vel = self.max_velocity * cooling;
+        let max_force = self.max_velocity * 2.0;
         self.total_steps += 1;
 
         let n = self.positions.len();
@@ -729,16 +761,6 @@ impl LayoutState {
     /// layout has settled and repaints can stop.
     pub fn energy(&self) -> f32 {
         self.velocities.iter().map(|v| v.length_squared()).sum()
-    }
-
-    /// Shared reference to the current force parameters.
-    pub fn params(&self) -> &ForceParams {
-        &self.params
-    }
-
-    /// Mutable reference to the force parameters for live-tweaking.
-    pub fn params_mut(&mut self) -> &mut ForceParams {
-        &mut self.params
     }
 
     /// Partially reset the cooling schedule so parameter changes take visible

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -388,6 +388,10 @@ impl LayoutState {
                 params.edge_params.clone(),
                 params.attraction_enabled,
             )),
+            Box::new(forces::Containment::new(
+                params.containment_strength,
+                params.containment_enabled,
+            )),
             Box::new(forces::LocationAffinity::new(
                 params.location_strength,
                 params.location_falloff,
@@ -446,6 +450,8 @@ impl LayoutState {
         let location_strength = self.params.location_strength;
         let location_falloff = self.params.location_falloff;
         let location_enabled = self.params.location_enabled;
+        let containment_strength = self.params.containment_strength;
+        let containment_enabled = self.params.containment_enabled;
         for force in self.forces.iter_mut() {
             let any = force.as_any_mut();
             if let Some(g) = any.downcast_mut::<forces::Gravity>() {
@@ -472,6 +478,11 @@ impl LayoutState {
                 l.strength = location_strength;
                 l.falloff = location_falloff;
                 l.enabled = location_enabled;
+                continue;
+            }
+            if let Some(c) = any.downcast_mut::<forces::Containment>() {
+                c.strength = containment_strength;
+                c.enabled = containment_enabled;
                 continue;
             }
         }
@@ -524,51 +535,13 @@ impl LayoutState {
             // a `Force` further down instead of seeding this buffer itself.
             let mut forces = vec![Vec2::ZERO; len];
 
-            // Containment force: each container pulls its DIRECT children
-            // toward their centroid. Top-level containers (TU/Namespace)
-            // use half strength so class-level containment dominates.
-            if p.containment_enabled && p.containment_strength > 0.0 {
-                for &c in &self.containers {
-                    if !self.active[c] {
-                        continue;
-                    }
-                    let children = &self.children_of[c];
-                    if children.len() < 2 {
-                        continue;
-                    }
-                    let mut centroid = Vec2::ZERO;
-                    let mut count = 0u32;
-                    for &child in children {
-                        if self.active[child] {
-                            centroid += self.positions[child];
-                            count += 1;
-                        }
-                    }
-                    if count < 2 {
-                        continue;
-                    }
-                    centroid /= count as f32;
-
-                    let strength = if self.toplevel_containers.contains(&c) {
-                        p.containment_strength * 0.5
-                    } else {
-                        p.containment_strength
-                    };
-                    for &child in children {
-                        if self.active[child] {
-                            forces[child] += (centroid - self.positions[child]) * strength;
-                        }
-                    }
-                }
-            }
-
             // --- Extracted forces pipeline (issue #33) ---
             //
             // Forces that have been migrated out of this inline code run
             // through the trait-based pipeline. Currently: repulsion,
-            // spring attraction, location affinity, gravity. Future
-            // extractions (containment, container repulsion) will append
-            // to `self.forces` and delete more of the inline code below.
+            // spring attraction, containment, location affinity, gravity.
+            // The last remaining inline force (container repulsion) will
+            // be extracted next.
             let ctx = forces::ForceContext {
                 positions: &self.positions,
                 sizes: &self.sizes,

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -12,6 +12,7 @@ pub mod forces;
 use core_ir::{EdgeKind, Graph, SymbolId, SymbolKind};
 use glam::Vec2;
 use indexmap::IndexMap;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
@@ -539,45 +540,75 @@ impl LayoutState {
     /// Applies adaptive cooling (damping decays over time), clamps per-node
     /// force and velocity magnitudes, skips hidden nodes, and holds pinned
     /// nodes at their fixed positions. Increments `total_steps`.
+    ///
+    /// Above [`forces::PARALLEL_THRESHOLD`] nodes the per-node update runs
+    /// under rayon: each iteration writes exactly one position/velocity
+    /// slot, so the work parallelises without contention.
     fn integrate(&mut self, forces: &[Vec2]) {
-        let p = &self.params;
-        // Adaptive cooling: damping decreases over time so the layout
-        // progressively freezes into place.
         let cooling = (1.0 - (self.total_steps as f32 / 300.0).min(0.95)).max(0.05);
-        let effective_damping = p.damping * cooling;
-        let max_vel = p.max_velocity * cooling;
-        let max_force = p.max_velocity * 2.0;
+        let effective_damping = self.params.damping * cooling;
+        let max_vel = self.params.max_velocity * cooling;
+        let max_force = self.params.max_velocity * 2.0;
         self.total_steps += 1;
 
-        for (i, (((id, pos), vel), force)) in self
-            .ids
-            .iter()
-            .zip(self.positions.iter_mut())
-            .zip(self.velocities.iter_mut())
-            .zip(forces.iter())
-            .enumerate()
-        {
-            if !self.active[i] {
+        let n = self.positions.len();
+        if n == 0 {
+            return;
+        }
+
+        // Split `self` into disjoint field borrows so the parallel loop
+        // can hold mutable borrows on positions/velocities while sharing
+        // `active`, `ids`, and `pins` across worker threads.
+        let positions = &mut self.positions;
+        let velocities = &mut self.velocities;
+        let active: &[bool] = &self.active;
+        let ids: &[SymbolId] = &self.ids;
+        let pins = &self.pins;
+
+        // Per-node integration step, shared between the serial and
+        // parallel paths so the math stays identical.
+        let integrate_one = |i: usize, pos: &mut Vec2, vel: &mut Vec2, force: Vec2| {
+            if !active[i] {
                 *vel = Vec2::ZERO;
-                continue;
+                return;
             }
-            if let Some(&pin_pos) = self.pins.get(id) {
+            if let Some(&pin_pos) = pins.get(&ids[i]) {
                 *pos = pin_pos;
                 *vel = Vec2::ZERO;
-            } else {
-                // Clamp force magnitude to prevent explosive acceleration
-                // when nodes are very close or container overlaps are large.
-                let mut f = *force;
-                let f_mag = f.length();
-                if f_mag > max_force {
-                    f *= max_force / f_mag;
-                }
-                *vel = (*vel + f) * effective_damping;
-                let speed = vel.length();
-                if speed > max_vel {
-                    *vel *= max_vel / speed;
-                }
-                *pos += *vel;
+                return;
+            }
+            // Clamp force magnitude to prevent explosive acceleration
+            // when nodes are very close or container overlaps are large.
+            let mut f = force;
+            let f_mag = f.length();
+            if f_mag > max_force {
+                f *= max_force / f_mag;
+            }
+            *vel = (*vel + f) * effective_damping;
+            let speed = vel.length();
+            if speed > max_vel {
+                *vel *= max_vel / speed;
+            }
+            *pos += *vel;
+        };
+
+        if n >= forces::PARALLEL_THRESHOLD {
+            positions
+                .par_iter_mut()
+                .zip(velocities.par_iter_mut())
+                .zip(forces.par_iter())
+                .enumerate()
+                .for_each(|(i, ((pos, vel), force))| {
+                    integrate_one(i, pos, vel, *force);
+                });
+        } else {
+            for (i, ((pos, vel), force)) in positions
+                .iter_mut()
+                .zip(velocities.iter_mut())
+                .zip(forces.iter())
+                .enumerate()
+            {
+                integrate_one(i, pos, vel, *force);
             }
         }
     }

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -444,9 +444,7 @@ impl LayoutState {
     }
 
     /// Snapshot the current tunable parameters into a [`ForceParams`]
-    /// struct for serialization to `spaghetti_settings.json`. Reads
-    /// each value from its canonical home: integration params come from
-    /// `self`, force-specific params come from the pipeline entries.
+    /// struct for serialization to `spaghetti_settings.json`.
     pub fn export_params(&self) -> ForceParams {
         let mut out = ForceParams {
             damping: self.damping,
@@ -485,9 +483,7 @@ impl LayoutState {
         out
     }
 
-    /// Apply a [`ForceParams`] snapshot to the simulation, writing
-    /// each value directly into its canonical home (integration params
-    /// on `self`, force params on the pipeline entries).
+    /// Apply a [`ForceParams`] snapshot to the simulation.
     pub fn import_params(&mut self, params: &ForceParams) {
         self.damping = params.damping;
         self.max_velocity = params.max_velocity;
@@ -603,10 +599,18 @@ impl LayoutState {
     /// force and velocity magnitudes, skips hidden nodes, and holds pinned
     /// nodes at their fixed positions. Increments `total_steps`.
     ///
-    /// Above [`forces::PARALLEL_THRESHOLD`] nodes the per-node update runs
-    /// under rayon: each iteration writes exactly one position/velocity
-    /// slot, so the work parallelises without contention.
+    /// Per-node work here is a handful of arithmetic ops plus one
+    /// hash-map lookup for pin state — much cheaper than any `Force`
+    /// inner loop, so the parallel path only kicks in on much larger
+    /// graphs than [`forces::PARALLEL_THRESHOLD`]. Below that, rayon's
+    /// setup cost dominates.
     fn integrate(&mut self, forces: &[Vec2]) {
+        /// Node-count threshold above which integration runs under
+        /// rayon. Much larger than the force-apply threshold because
+        /// per-node integrate work is O(1) constants rather than
+        /// O(neighbourhood).
+        const INTEGRATE_PARALLEL_THRESHOLD: usize = 5000;
+
         let cooling = (1.0 - (self.total_steps as f32 / 300.0).min(0.95)).max(0.05);
         let effective_damping = self.damping * cooling;
         let max_vel = self.max_velocity * cooling;
@@ -627,8 +631,6 @@ impl LayoutState {
         let ids: &[SymbolId] = &self.ids;
         let pins = &self.pins;
 
-        // Per-node integration step, shared between the serial and
-        // parallel paths so the math stays identical.
         let integrate_one = |i: usize, pos: &mut Vec2, vel: &mut Vec2, force: Vec2| {
             if !active[i] {
                 *vel = Vec2::ZERO;
@@ -654,7 +656,7 @@ impl LayoutState {
             *pos += *vel;
         };
 
-        if n >= forces::PARALLEL_THRESHOLD {
+        if n >= INTEGRATE_PARALLEL_THRESHOLD {
             positions
                 .par_iter_mut()
                 .zip(velocities.par_iter_mut())
@@ -764,7 +766,8 @@ impl LayoutState {
     }
 
     /// Partially reset the cooling schedule so parameter changes take visible
-    /// effect. Call after modifying [`ForceParams`] via [`params_mut`](Self::params_mut).
+    /// effect. Call after tuning a force via
+    /// [`force_mut`](Self::force_mut) or [`import_params`](Self::import_params).
     pub fn reheat(&mut self) {
         self.total_steps = self.total_steps.saturating_sub(100);
     }

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -262,6 +262,10 @@ pub struct LayoutState {
     /// Groups of sibling container indices (containers sharing the same parent).
     /// Container repulsion only acts within each sibling group.
     sibling_groups: Vec<Vec<usize>>,
+    /// Composable force pipeline. Forces are progressively extracted out of
+    /// `step_inner` into this list (see issue #33). On each step, every
+    /// enabled force accumulates contributions into the shared force buffer.
+    forces: Vec<Box<dyn forces::Force>>,
 }
 
 impl LayoutState {
@@ -360,6 +364,16 @@ impl LayoutState {
         let collapse_hidden = HashSet::new();
         let hidden = HashSet::new();
 
+        // Build the force pipeline. Forces are progressively extracted out
+        // of the inline code in `step_inner` (see issue #33). Each force
+        // carries its own enabled flag and tunable parameters, kept in sync
+        // with `ForceParams` via `sync_forces_from_params` until Phase 3
+        // removes the facade entirely.
+        let force_pipeline: Vec<Box<dyn forces::Force>> = vec![Box::new(forces::Gravity::new(
+            params.gravity,
+            params.gravity_enabled,
+        ))];
+
         Self {
             ids,
             positions,
@@ -383,6 +397,23 @@ impl LayoutState {
             external_hidden: HashSet::new(),
             sizes: vec![Vec2::new(120.0, 30.0); n],
             sibling_groups,
+            forces: force_pipeline,
+        }
+    }
+
+    /// Copy parameter values from the legacy [`ForceParams`] struct into
+    /// each extracted force. This keeps the existing `params_mut()` /
+    /// settings-load flow working while forces are progressively extracted.
+    /// Phase 3 of issue #33 will replace it with `export_params` /
+    /// `import_params` and remove `ForceParams` from `LayoutState`.
+    fn sync_forces_from_params(&mut self) {
+        let gravity_strength = self.params.gravity;
+        let gravity_enabled = self.params.gravity_enabled;
+        for force in self.forces.iter_mut() {
+            if let Some(g) = force.as_any_mut().downcast_mut::<forces::Gravity>() {
+                g.strength = gravity_strength;
+                g.enabled = gravity_enabled;
+            }
         }
     }
 
@@ -420,6 +451,11 @@ impl LayoutState {
         if len == 0 {
             return;
         }
+
+        // Push the latest tunable values from `self.params` into any
+        // already-extracted forces before stepping.
+        self.sync_forces_from_params();
+
         let p = &self.params;
 
         for _ in 0..n {
@@ -606,25 +642,33 @@ impl LayoutState {
                 }
             }
 
-            // Gravity: gentle pull toward the centroid (skip hidden)
-            if p.gravity_enabled && p.gravity > 0.0 {
-                let mut centroid = Vec2::ZERO;
-                let mut visible_count = 0u32;
-                for (i, pos) in self.positions.iter().enumerate() {
-                    if !self.hidden.contains(&i) {
-                        centroid += *pos;
-                        visible_count += 1;
-                    }
-                }
-                if visible_count > 0 {
-                    centroid /= visible_count as f32;
-                    for (i, (force, pos)) in
-                        forces.iter_mut().zip(self.positions.iter()).enumerate()
-                    {
-                        if !self.hidden.contains(&i) {
-                            *force += (centroid - *pos) * p.gravity;
-                        }
-                    }
+            // --- Extracted forces pipeline (issue #33) ---
+            //
+            // Forces that have been migrated out of this inline code run
+            // through the trait-based pipeline. Currently: gravity. Future
+            // extractions (repulsion, spring attraction, etc.) will append
+            // to `self.forces` and delete more of the inline code.
+            //
+            // `active` is rebuilt per-step from the current hidden set. Step
+            // 1c of the refactor will replace this with a persistent
+            // `Vec<bool>` on `LayoutState` (see the §1 optimization).
+            let active: Vec<bool> = (0..len).map(|i| !self.hidden.contains(&i)).collect();
+            let ctx = forces::ForceContext {
+                positions: &self.positions,
+                sizes: &self.sizes,
+                degrees: &self.degrees,
+                active: &active,
+                edge_pairs: &self.edge_pairs,
+                visible_edge_kinds: &self.visible_edge_kinds,
+                children_of: &self.children_of,
+                containers: &self.containers,
+                expanded: &self.expanded,
+                toplevel_containers: &self.toplevel_containers,
+                node_count: len,
+            };
+            for force in &self.forces {
+                if force.enabled() {
+                    force.apply(&ctx, &mut forces);
                 }
             }
 

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -7,6 +7,8 @@
 //! - [`LayoutState`]: incremental simulation driven frame-by-frame, with
 //!   support for pinning nodes (interactive dragging).
 
+pub mod forces;
+
 use core_ir::{EdgeKind, Graph, SymbolId, SymbolKind};
 use glam::Vec2;
 use indexmap::IndexMap;

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -438,6 +438,20 @@ impl LayoutState {
             .find_map(|f| f.as_any_mut().downcast_mut::<T>())
     }
 
+    /// Snapshot the current tunable parameters into a [`ForceParams`]
+    /// struct for serialization to `spaghetti_settings.json`.
+    pub fn export_params(&self) -> ForceParams {
+        self.params.clone()
+    }
+
+    /// Apply a [`ForceParams`] snapshot to the simulation. Individual
+    /// force params are propagated into the pipeline on the next
+    /// [`step`](Self::step) via the same sync mechanism `params_mut`
+    /// already uses.
+    pub fn import_params(&mut self, params: &ForceParams) {
+        self.params = params.clone();
+    }
+
     /// Copy parameter values from [`ForceParams`] into each pipeline
     /// force. Runs once per `step_inner` call so UI-driven param edits
     /// take effect immediately without plumbing a setter per field.

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -387,6 +387,13 @@ impl LayoutState {
                 params.min_dist,
                 params.repulsion_enabled,
             )),
+            Box::new(forces::SpringAttraction::new(
+                params.attraction,
+                params.ideal_length,
+                params.min_dist,
+                params.edge_params.clone(),
+                params.attraction_enabled,
+            )),
             Box::new(forces::Gravity::new(params.gravity, params.gravity_enabled)),
         ];
 
@@ -424,13 +431,19 @@ impl LayoutState {
     /// `import_params` and remove `ForceParams` from `LayoutState`.
     fn sync_forces_from_params(&mut self) {
         // Snapshot relevant scalars first — we can't hold `&self.params`
-        // while also mutably iterating `self.forces`.
+        // while also mutably iterating `self.forces`. `edge_params` is
+        // cloned because `SpringAttraction` owns its own copy.
         let gravity_strength = self.params.gravity;
         let gravity_enabled = self.params.gravity_enabled;
         let repulsion_strength = self.params.repulsion;
         let repulsion_cutoff = self.params.repulsion_cutoff;
         let repulsion_min_dist = self.params.min_dist;
         let repulsion_enabled = self.params.repulsion_enabled;
+        let attraction_strength = self.params.attraction;
+        let attraction_ideal_length = self.params.ideal_length;
+        let attraction_min_dist = self.params.min_dist;
+        let attraction_enabled = self.params.attraction_enabled;
+        let attraction_edge_params = self.params.edge_params.clone();
         for force in self.forces.iter_mut() {
             let any = force.as_any_mut();
             if let Some(g) = any.downcast_mut::<forces::Gravity>() {
@@ -443,6 +456,14 @@ impl LayoutState {
                 r.cutoff = repulsion_cutoff;
                 r.min_dist = repulsion_min_dist;
                 r.enabled = repulsion_enabled;
+                continue;
+            }
+            if let Some(s) = any.downcast_mut::<forces::SpringAttraction>() {
+                s.global_attraction = attraction_strength;
+                s.global_ideal_length = attraction_ideal_length;
+                s.min_dist = attraction_min_dist;
+                s.enabled = attraction_enabled;
+                s.edge_params = attraction_edge_params.clone();
                 continue;
             }
         }
@@ -494,34 +515,6 @@ impl LayoutState {
             // Fresh accumulator for this iteration. Repulsion now runs as
             // a `Force` further down instead of seeding this buffer itself.
             let mut forces = vec![Vec2::ZERO; len];
-
-            // Attractive forces along visible edges only (per-edge-kind params).
-            //
-            // Linear spring, but each endpoint's force is divided by
-            // sqrt(degree) so hub nodes (many connections) don't get
-            // yanked across the canvas by the sum of all their edges.
-            if p.attraction_enabled {
-                for &(from, to, kind) in &self.edge_pairs {
-                    if !self.visible_edge_kinds.contains(&kind) {
-                        continue;
-                    }
-                    if !self.active[from] || !self.active[to] {
-                        continue;
-                    }
-                    let (attr, rest_len) = if let Some(ep) = p.edge_params.get(&kind) {
-                        (ep.attraction, ep.target_distance)
-                    } else {
-                        (p.attraction, p.ideal_length)
-                    };
-                    let delta = self.positions[to] - self.positions[from];
-                    let dist = delta.length().max(p.min_dist);
-                    let displacement = attr * (dist - rest_len);
-                    let dir = delta.normalize_or_zero();
-                    // Scale by 1/sqrt(degree) at each endpoint so hubs stay calm.
-                    forces[from] += dir * displacement / self.degrees[from].sqrt();
-                    forces[to] -= dir * displacement / self.degrees[to].sqrt();
-                }
-            }
 
             // Containment force: each container pulls its DIRECT children
             // toward their centroid. Top-level containers (TU/Namespace)
@@ -606,9 +599,9 @@ impl LayoutState {
             //
             // Forces that have been migrated out of this inline code run
             // through the trait-based pipeline. Currently: repulsion,
-            // gravity. Future extractions (spring attraction, containment,
-            // etc.) will append to `self.forces` and delete more of the
-            // inline code below.
+            // spring attraction, gravity. Future extractions (containment,
+            // location affinity, container repulsion) will append to
+            // `self.forces` and delete more of the inline code below.
             let ctx = forces::ForceContext {
                 positions: &self.positions,
                 sizes: &self.sizes,

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -528,27 +528,17 @@ impl LayoutState {
             return;
         }
 
-        // Push the latest tunable values from `self.params` into any
-        // already-extracted forces before stepping.
+        // Push the latest tunable values from `self.params` into the
+        // force pipeline once per call.
         self.sync_forces_from_params();
-
-        let p = &self.params;
 
         for _ in 0..n {
             if early_stop && self.energy() < EARLY_STOP_ENERGY {
                 break;
             }
 
-            // Fresh accumulator for this iteration. Repulsion now runs as
-            // a `Force` further down instead of seeding this buffer itself.
+            // Accumulate all forces into a fresh buffer.
             let mut forces = vec![Vec2::ZERO; len];
-
-            // --- Force pipeline ---
-            //
-            // All forces now run through the trait-based pipeline:
-            // repulsion, spring attraction, containment, container
-            // repulsion, location affinity, gravity. step_inner is down
-            // to ctx setup → accumulate → integrate → clamp.
             let ctx = forces::ForceContext {
                 positions: &self.positions,
                 sizes: &self.sizes,
@@ -568,68 +558,83 @@ impl LayoutState {
                 }
             }
 
-            // Adaptive cooling: damping decreases over time so the layout
-            // progressively freezes into place.
-            let cooling = (1.0 - (self.total_steps as f32 / 300.0).min(0.95)).max(0.05);
-            let effective_damping = p.damping * cooling;
-            let max_vel = p.max_velocity * cooling;
-            self.total_steps += 1;
+            // Integrate velocity/position, then clamp descendants of
+            // collapsed containers inside their parent's bounding box.
+            self.integrate(&forces);
+            self.clamp_collapsed();
+        }
+    }
 
-            // Update velocities and positions (skip pinned and hidden nodes)
-            for (i, (((id, pos), vel), force)) in self
-                .ids
-                .iter()
-                .zip(self.positions.iter_mut())
-                .zip(self.velocities.iter_mut())
-                .zip(forces.iter())
-                .enumerate()
-            {
-                if !self.active[i] {
-                    *vel = Vec2::ZERO;
-                    continue;
-                }
-                if let Some(&pin_pos) = self.pins.get(id) {
-                    *pos = pin_pos;
-                    *vel = Vec2::ZERO;
-                } else {
-                    // Clamp force magnitude to prevent explosive acceleration
-                    // when nodes are very close or container overlaps are large.
-                    let mut f = *force;
-                    let f_mag = f.length();
-                    let max_force = p.max_velocity * 2.0;
-                    if f_mag > max_force {
-                        f *= max_force / f_mag;
-                    }
-                    *vel = (*vel + f) * effective_damping;
-                    let speed = vel.length();
-                    if speed > max_vel {
-                        *vel *= max_vel / speed;
-                    }
-                    *pos += *vel;
-                }
+    /// Update velocities and positions from an accumulated force buffer.
+    ///
+    /// Applies adaptive cooling (damping decays over time), clamps per-node
+    /// force and velocity magnitudes, skips hidden nodes, and holds pinned
+    /// nodes at their fixed positions. Increments `total_steps`.
+    fn integrate(&mut self, forces: &[Vec2]) {
+        let p = &self.params;
+        // Adaptive cooling: damping decreases over time so the layout
+        // progressively freezes into place.
+        let cooling = (1.0 - (self.total_steps as f32 / 300.0).min(0.95)).max(0.05);
+        let effective_damping = p.damping * cooling;
+        let max_vel = p.max_velocity * cooling;
+        let max_force = p.max_velocity * 2.0;
+        self.total_steps += 1;
+
+        for (i, (((id, pos), vel), force)) in self
+            .ids
+            .iter()
+            .zip(self.positions.iter_mut())
+            .zip(self.velocities.iter_mut())
+            .zip(forces.iter())
+            .enumerate()
+        {
+            if !self.active[i] {
+                *vel = Vec2::ZERO;
+                continue;
             }
+            if let Some(&pin_pos) = self.pins.get(id) {
+                *pos = pin_pos;
+                *vel = Vec2::ZERO;
+            } else {
+                // Clamp force magnitude to prevent explosive acceleration
+                // when nodes are very close or container overlaps are large.
+                let mut f = *force;
+                let f_mag = f.length();
+                if f_mag > max_force {
+                    f *= max_force / f_mag;
+                }
+                *vel = (*vel + f) * effective_damping;
+                let speed = vel.length();
+                if speed > max_vel {
+                    *vel *= max_vel / speed;
+                }
+                *pos += *vel;
+            }
+        }
+    }
 
-            // Clamp ALL descendants of collapsed containers inside a
-            // fixed box around the parent position.
-            for &c in &self.containers {
-                if self.expanded.contains(&c) || !self.active[c] {
+    /// Clamp every descendant of a collapsed (non-expanded) container
+    /// inside a fixed-size box around the container's current position.
+    /// Expanded containers let their descendants move freely.
+    fn clamp_collapsed(&mut self) {
+        for &c in &self.containers {
+            if self.expanded.contains(&c) || !self.active[c] {
+                continue;
+            }
+            let center = self.positions[c];
+            for &d in &self.all_descendants_idx(c) {
+                if !self.active[d] {
                     continue;
                 }
-                let center = self.positions[c];
-                for &d in &self.all_descendants_idx(c) {
-                    if !self.active[d] {
-                        continue;
-                    }
-                    let pos = &mut self.positions[d];
-                    pos.x = pos.x.clamp(
-                        center.x - COLLAPSED_HALF_SIZE.x,
-                        center.x + COLLAPSED_HALF_SIZE.x,
-                    );
-                    pos.y = pos.y.clamp(
-                        center.y - COLLAPSED_HALF_SIZE.y,
-                        center.y + COLLAPSED_HALF_SIZE.y,
-                    );
-                }
+                let pos = &mut self.positions[d];
+                pos.x = pos.x.clamp(
+                    center.x - COLLAPSED_HALF_SIZE.x,
+                    center.x + COLLAPSED_HALF_SIZE.x,
+                );
+                pos.y = pos.y.clamp(
+                    center.y - COLLAPSED_HALF_SIZE.y,
+                    center.y + COLLAPSED_HALF_SIZE.y,
+                );
             }
         }
     }

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -260,9 +260,6 @@ pub struct LayoutState {
     /// Per-node bounding box sizes in world units. Used for size-aware
     /// repulsion (edge-to-edge distance instead of center-to-center).
     sizes: Vec<Vec2>,
-    /// Groups of sibling container indices (containers sharing the same parent).
-    /// Container repulsion only acts within each sibling group.
-    sibling_groups: Vec<Vec<usize>>,
     /// Composable force pipeline. Forces are progressively extracted out of
     /// `step_inner` into this list (see issue #33). On each step, every
     /// enabled force accumulates contributions into the shared force buffer.
@@ -392,6 +389,11 @@ impl LayoutState {
                 params.containment_strength,
                 params.containment_enabled,
             )),
+            Box::new(forces::ContainerRepulsion::new(
+                params.container_repulsion,
+                sibling_groups,
+                params.container_repulsion_enabled,
+            )),
             Box::new(forces::LocationAffinity::new(
                 params.location_strength,
                 params.location_falloff,
@@ -422,7 +424,6 @@ impl LayoutState {
             collapse_hidden,
             external_hidden,
             sizes: vec![Vec2::new(120.0, 30.0); n],
-            sibling_groups,
             forces: force_pipeline,
         }
     }
@@ -452,6 +453,8 @@ impl LayoutState {
         let location_enabled = self.params.location_enabled;
         let containment_strength = self.params.containment_strength;
         let containment_enabled = self.params.containment_enabled;
+        let container_repulsion_strength = self.params.container_repulsion;
+        let container_repulsion_enabled = self.params.container_repulsion_enabled;
         for force in self.forces.iter_mut() {
             let any = force.as_any_mut();
             if let Some(g) = any.downcast_mut::<forces::Gravity>() {
@@ -483,6 +486,11 @@ impl LayoutState {
             if let Some(c) = any.downcast_mut::<forces::Containment>() {
                 c.strength = containment_strength;
                 c.enabled = containment_enabled;
+                continue;
+            }
+            if let Some(cr) = any.downcast_mut::<forces::ContainerRepulsion>() {
+                cr.strength = container_repulsion_strength;
+                cr.enabled = container_repulsion_enabled;
                 continue;
             }
         }
@@ -535,13 +543,12 @@ impl LayoutState {
             // a `Force` further down instead of seeding this buffer itself.
             let mut forces = vec![Vec2::ZERO; len];
 
-            // --- Extracted forces pipeline (issue #33) ---
+            // --- Force pipeline ---
             //
-            // Forces that have been migrated out of this inline code run
-            // through the trait-based pipeline. Currently: repulsion,
-            // spring attraction, containment, location affinity, gravity.
-            // The last remaining inline force (container repulsion) will
-            // be extracted next.
+            // All forces now run through the trait-based pipeline:
+            // repulsion, spring attraction, containment, container
+            // repulsion, location affinity, gravity. step_inner is down
+            // to ctx setup → accumulate → integrate → clamp.
             let ctx = forces::ForceContext {
                 positions: &self.positions,
                 sizes: &self.sizes,
@@ -558,103 +565,6 @@ impl LayoutState {
             for force in &self.forces {
                 if force.enabled() {
                     force.apply(&ctx, &mut forces);
-                }
-            }
-
-            // Container overlap resolution: push sibling containers apart
-            // only when their bounding boxes actually overlap. Force is
-            // proportional to overlap depth so containers separate just
-            // enough to stop intersecting, then stop receiving force.
-            if p.container_repulsion_enabled && p.container_repulsion > 0.0 {
-                let cr = p.container_repulsion;
-                for group in &self.sibling_groups {
-                    // Collect the expanded, visible containers in this group.
-                    let live_siblings: Vec<usize> = group
-                        .iter()
-                        .copied()
-                        .filter(|&c| self.active[c] && self.expanded.contains(&c))
-                        .collect();
-                    if live_siblings.len() < 2 {
-                        continue;
-                    }
-
-                    // Grid-accelerated overlap detection: bucket containers by
-                    // cell so we only check nearby pairs instead of all O(S²).
-                    let max_extent = live_siblings
-                        .iter()
-                        .map(|&c| self.sizes[c].x.max(self.sizes[c].y))
-                        .fold(0.0f32, f32::max);
-                    // Cell size = largest container extent so overlapping pairs
-                    // are always in the same or adjacent cells.
-                    let cell_size = max_extent.max(1.0);
-                    let inv_cell = 1.0 / cell_size;
-
-                    let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
-                    for &c in &live_siblings {
-                        let cx = (self.positions[c].x * inv_cell).floor() as i32;
-                        let cy = (self.positions[c].y * inv_cell).floor() as i32;
-                        grid.entry((cx, cy)).or_default().push(c);
-                    }
-
-                    // Check each container against neighbours in a 3×3 cell window.
-                    for &a in &live_siblings {
-                        let pos_a = self.positions[a];
-                        let half_a = self.sizes[a] * 0.5;
-                        let ax = (pos_a.x * inv_cell).floor() as i32;
-                        let ay = (pos_a.y * inv_cell).floor() as i32;
-
-                        for dx in -1i32..=1 {
-                            for dy in -1i32..=1 {
-                                let key = (ax.wrapping_add(dx), ay.wrapping_add(dy));
-                                let Some(bucket) = grid.get(&key) else {
-                                    continue;
-                                };
-                                for &b in bucket {
-                                    // Avoid self-pairs and double-counting (a < b).
-                                    if b <= a {
-                                        continue;
-                                    }
-                                    let pos_b = self.positions[b];
-                                    let half_b = self.sizes[b] * 0.5;
-
-                                    // AABB overlap test on each axis.
-                                    let overlap_x =
-                                        (half_a.x + half_b.x) - (pos_a.x - pos_b.x).abs();
-                                    let overlap_y =
-                                        (half_a.y + half_b.y) - (pos_a.y - pos_b.y).abs();
-
-                                    if overlap_x <= 0.0 || overlap_y <= 0.0 {
-                                        continue; // No overlap — skip.
-                                    }
-
-                                    // Push apart along the axis of least overlap
-                                    // (minimum penetration direction).
-                                    let delta = pos_a - pos_b;
-                                    let f = if overlap_x < overlap_y {
-                                        Vec2::new(delta.x.signum() * overlap_x * cr, 0.0)
-                                    } else {
-                                        Vec2::new(0.0, delta.y.signum() * overlap_y * cr)
-                                    };
-
-                                    // Rigid-body: move container + all descendants.
-                                    apply_force_to_subtree(
-                                        a,
-                                        f,
-                                        &mut forces,
-                                        &self.children_of,
-                                        &self.active,
-                                    );
-                                    apply_force_to_subtree(
-                                        b,
-                                        -f,
-                                        &mut forces,
-                                        &self.children_of,
-                                        &self.active,
-                                    );
-                                }
-                            }
-                        }
-                    }
                 }
             }
 
@@ -1028,27 +938,6 @@ fn build_sibling_groups(
     }
     // Only keep groups with at least 2 siblings (single containers can't repel).
     by_parent.into_values().filter(|g| g.len() >= 2).collect()
-}
-
-/// Apply a force to a node and all its descendants (rigid-body translation).
-/// Walks the subtree via `children_of` without allocating. Descendants
-/// whose `active` flag is `false` are skipped.
-fn apply_force_to_subtree(
-    root: usize,
-    force: Vec2,
-    forces: &mut [Vec2],
-    children_of: &[Vec<usize>],
-    active: &[bool],
-) {
-    forces[root] += force;
-    // Use a manual stack to avoid recursion overhead.
-    let mut stack: Vec<usize> = children_of[root].clone();
-    while let Some(node) = stack.pop() {
-        if active[node] {
-            forces[node] += force;
-            stack.extend_from_slice(&children_of[node]);
-        }
-    }
 }
 
 /// Build hierarchical directory groups from the graph's file table.

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -12,7 +12,6 @@ pub mod forces;
 use core_ir::{EdgeKind, Graph, SymbolId, SymbolKind};
 use glam::Vec2;
 use indexmap::IndexMap;
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
@@ -233,8 +232,13 @@ pub struct LayoutState {
     degrees: Vec<f32>,
     /// Total steps run so far, used for adaptive cooling.
     total_steps: u32,
-    /// Node indices that are hidden (excluded from all force computation).
-    hidden: HashSet<usize>,
+    /// Per-node visibility flag. `active[i] == true` means node `i`
+    /// participates in the simulation this step. Rebuilt from
+    /// [`Self::collapse_hidden`] and [`Self::external_hidden`] by
+    /// [`Self::rebuild_active`]. Kept as a dense `Vec<bool>` so the hot
+    /// path can test visibility with an array lookup instead of a
+    /// `HashSet::contains` call (§1 of issue #33).
+    active: Vec<bool>,
     /// Hierarchical directory groups for the location-affinity force.
     /// `dir_groups[depth][group_idx]` is a list of node indices sharing
     /// the same directory prefix at that depth.
@@ -252,10 +256,13 @@ pub struct LayoutState {
     toplevel_containers: HashSet<usize>,
     /// Which containers are currently expanded (children visible).
     expanded: HashSet<usize>,
-    /// Nodes hidden by collapse (tracked separately from file-tree hidden).
-    collapse_hidden: HashSet<usize>,
-    /// Nodes hidden by external callers (file-tree visibility).
-    external_hidden: HashSet<usize>,
+    /// Per-node collapse-hidden flag. Nodes marked `true` are currently
+    /// hidden by a collapsed ancestor container (tracked separately from
+    /// file-tree hidden).
+    collapse_hidden: Vec<bool>,
+    /// Per-node external-hidden flag. Nodes marked `true` are currently
+    /// hidden by an external caller (e.g. the file-tree visibility panel).
+    external_hidden: Vec<bool>,
     /// Per-node bounding box sizes in world units. Used for size-aware
     /// repulsion (edge-to-edge distance instead of center-to-center).
     sizes: Vec<Vec2>,
@@ -361,18 +368,27 @@ impl LayoutState {
         // simulation (visible, participate in forces) but are clamped
         // inside the collapsed container box each step.
         let expanded = HashSet::new();
-        let collapse_hidden = HashSet::new();
-        let hidden = HashSet::new();
+
+        // Visibility bookkeeping: both "hidden" sources start empty, so
+        // every node is active at construction time.
+        let collapse_hidden = vec![false; n];
+        let external_hidden = vec![false; n];
+        let active = vec![true; n];
 
         // Build the force pipeline. Forces are progressively extracted out
         // of the inline code in `step_inner` (see issue #33). Each force
         // carries its own enabled flag and tunable parameters, kept in sync
         // with `ForceParams` via `sync_forces_from_params` until Phase 3
         // removes the facade entirely.
-        let force_pipeline: Vec<Box<dyn forces::Force>> = vec![Box::new(forces::Gravity::new(
-            params.gravity,
-            params.gravity_enabled,
-        ))];
+        let force_pipeline: Vec<Box<dyn forces::Force>> = vec![
+            Box::new(forces::Repulsion::new(
+                params.repulsion,
+                params.repulsion_cutoff,
+                params.min_dist,
+                params.repulsion_enabled,
+            )),
+            Box::new(forces::Gravity::new(params.gravity, params.gravity_enabled)),
+        ];
 
         Self {
             ids,
@@ -385,7 +401,7 @@ impl LayoutState {
             params,
             degrees,
             total_steps: 0,
-            hidden,
+            active,
             dir_groups,
             max_dir_depth,
             parent_of,
@@ -394,7 +410,7 @@ impl LayoutState {
             toplevel_containers,
             expanded,
             collapse_hidden,
-            external_hidden: HashSet::new(),
+            external_hidden,
             sizes: vec![Vec2::new(120.0, 30.0); n],
             sibling_groups,
             forces: force_pipeline,
@@ -407,12 +423,27 @@ impl LayoutState {
     /// Phase 3 of issue #33 will replace it with `export_params` /
     /// `import_params` and remove `ForceParams` from `LayoutState`.
     fn sync_forces_from_params(&mut self) {
+        // Snapshot relevant scalars first — we can't hold `&self.params`
+        // while also mutably iterating `self.forces`.
         let gravity_strength = self.params.gravity;
         let gravity_enabled = self.params.gravity_enabled;
+        let repulsion_strength = self.params.repulsion;
+        let repulsion_cutoff = self.params.repulsion_cutoff;
+        let repulsion_min_dist = self.params.min_dist;
+        let repulsion_enabled = self.params.repulsion_enabled;
         for force in self.forces.iter_mut() {
-            if let Some(g) = force.as_any_mut().downcast_mut::<forces::Gravity>() {
+            let any = force.as_any_mut();
+            if let Some(g) = any.downcast_mut::<forces::Gravity>() {
                 g.strength = gravity_strength;
                 g.enabled = gravity_enabled;
+                continue;
+            }
+            if let Some(r) = any.downcast_mut::<forces::Repulsion>() {
+                r.strength = repulsion_strength;
+                r.cutoff = repulsion_cutoff;
+                r.min_dist = repulsion_min_dist;
+                r.enabled = repulsion_enabled;
+                continue;
             }
         }
     }
@@ -443,9 +474,6 @@ impl LayoutState {
     fn step_inner(&mut self, n: u32, early_stop: bool) {
         /// Energy threshold below which batch layout stops early.
         const EARLY_STOP_ENERGY: f32 = 0.5;
-        /// Threshold below which we use serial computation (rayon overhead not
-        /// worth it for small graphs).
-        const PARALLEL_THRESHOLD: usize = 500;
 
         let len = self.positions.len();
         if len == 0 {
@@ -463,77 +491,9 @@ impl LayoutState {
                 break;
             }
 
-            // --- Repulsive forces via grid-based cutoff ---
-            let mut forces = if p.repulsion_enabled {
-                let cutoff = p.repulsion_cutoff;
-                let cutoff_sq = cutoff * cutoff;
-                let inv_cutoff = 1.0 / cutoff;
-                let repulsion = p.repulsion;
-                let min_dist = p.min_dist;
-
-                // Build spatial grid: assign each node to a cell (skip hidden).
-                let cell_keys: Vec<(i32, i32)> = self
-                    .positions
-                    .iter()
-                    .map(|pos| {
-                        let cx = (pos.x * inv_cutoff).floor() as i32;
-                        let cy = (pos.y * inv_cutoff).floor() as i32;
-                        (cx, cy)
-                    })
-                    .collect();
-
-                let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::with_capacity(len / 4 + 1);
-                for (i, &key) in cell_keys.iter().enumerate() {
-                    if !self.hidden.contains(&i) {
-                        grid.entry(key).or_default().push(i);
-                    }
-                }
-
-                let positions_ref = &self.positions;
-                let grid_ref = &grid;
-                let hidden_ref = &self.hidden;
-
-                if len >= PARALLEL_THRESHOLD {
-                    (0..len)
-                        .into_par_iter()
-                        .map(|i| {
-                            if hidden_ref.contains(&i) {
-                                return Vec2::ZERO;
-                            }
-                            compute_repulsion_for_node(
-                                i,
-                                positions_ref,
-                                grid_ref,
-                                &cell_keys,
-                                cutoff_sq,
-                                inv_cutoff,
-                                repulsion,
-                                min_dist,
-                            )
-                        })
-                        .collect()
-                } else {
-                    (0..len)
-                        .map(|i| {
-                            if hidden_ref.contains(&i) {
-                                return Vec2::ZERO;
-                            }
-                            compute_repulsion_for_node(
-                                i,
-                                positions_ref,
-                                grid_ref,
-                                &cell_keys,
-                                cutoff_sq,
-                                inv_cutoff,
-                                repulsion,
-                                min_dist,
-                            )
-                        })
-                        .collect()
-                }
-            } else {
-                vec![Vec2::ZERO; len]
-            };
+            // Fresh accumulator for this iteration. Repulsion now runs as
+            // a `Force` further down instead of seeding this buffer itself.
+            let mut forces = vec![Vec2::ZERO; len];
 
             // Attractive forces along visible edges only (per-edge-kind params).
             //
@@ -545,7 +505,7 @@ impl LayoutState {
                     if !self.visible_edge_kinds.contains(&kind) {
                         continue;
                     }
-                    if self.hidden.contains(&from) || self.hidden.contains(&to) {
+                    if !self.active[from] || !self.active[to] {
                         continue;
                     }
                     let (attr, rest_len) = if let Some(ep) = p.edge_params.get(&kind) {
@@ -568,7 +528,7 @@ impl LayoutState {
             // use half strength so class-level containment dominates.
             if p.containment_enabled && p.containment_strength > 0.0 {
                 for &c in &self.containers {
-                    if self.hidden.contains(&c) {
+                    if !self.active[c] {
                         continue;
                     }
                     let children = &self.children_of[c];
@@ -578,7 +538,7 @@ impl LayoutState {
                     let mut centroid = Vec2::ZERO;
                     let mut count = 0u32;
                     for &child in children {
-                        if !self.hidden.contains(&child) {
+                        if self.active[child] {
                             centroid += self.positions[child];
                             count += 1;
                         }
@@ -594,7 +554,7 @@ impl LayoutState {
                         p.containment_strength
                     };
                     for &child in children {
-                        if !self.hidden.contains(&child) {
+                        if self.active[child] {
                             forces[child] += (centroid - self.positions[child]) * strength;
                         }
                     }
@@ -623,7 +583,7 @@ impl LayoutState {
                         let mut centroid = Vec2::ZERO;
                         let mut count = 0u32;
                         for &idx in group {
-                            if !self.hidden.contains(&idx) {
+                            if self.active[idx] {
                                 centroid += self.positions[idx];
                                 count += 1;
                             }
@@ -634,7 +594,7 @@ impl LayoutState {
                         centroid /= count as f32;
 
                         for &idx in group {
-                            if !self.hidden.contains(&idx) {
+                            if self.active[idx] {
                                 forces[idx] += (centroid - self.positions[idx]) * strength;
                             }
                         }
@@ -645,19 +605,15 @@ impl LayoutState {
             // --- Extracted forces pipeline (issue #33) ---
             //
             // Forces that have been migrated out of this inline code run
-            // through the trait-based pipeline. Currently: gravity. Future
-            // extractions (repulsion, spring attraction, etc.) will append
-            // to `self.forces` and delete more of the inline code.
-            //
-            // `active` is rebuilt per-step from the current hidden set. Step
-            // 1c of the refactor will replace this with a persistent
-            // `Vec<bool>` on `LayoutState` (see the §1 optimization).
-            let active: Vec<bool> = (0..len).map(|i| !self.hidden.contains(&i)).collect();
+            // through the trait-based pipeline. Currently: repulsion,
+            // gravity. Future extractions (spring attraction, containment,
+            // etc.) will append to `self.forces` and delete more of the
+            // inline code below.
             let ctx = forces::ForceContext {
                 positions: &self.positions,
                 sizes: &self.sizes,
                 degrees: &self.degrees,
-                active: &active,
+                active: &self.active,
                 edge_pairs: &self.edge_pairs,
                 visible_edge_kinds: &self.visible_edge_kinds,
                 children_of: &self.children_of,
@@ -680,18 +636,18 @@ impl LayoutState {
                 let cr = p.container_repulsion;
                 for group in &self.sibling_groups {
                     // Collect the expanded, visible containers in this group.
-                    let active: Vec<usize> = group
+                    let live_siblings: Vec<usize> = group
                         .iter()
                         .copied()
-                        .filter(|&c| !self.hidden.contains(&c) && self.expanded.contains(&c))
+                        .filter(|&c| self.active[c] && self.expanded.contains(&c))
                         .collect();
-                    if active.len() < 2 {
+                    if live_siblings.len() < 2 {
                         continue;
                     }
 
                     // Grid-accelerated overlap detection: bucket containers by
                     // cell so we only check nearby pairs instead of all O(S²).
-                    let max_extent = active
+                    let max_extent = live_siblings
                         .iter()
                         .map(|&c| self.sizes[c].x.max(self.sizes[c].y))
                         .fold(0.0f32, f32::max);
@@ -701,14 +657,14 @@ impl LayoutState {
                     let inv_cell = 1.0 / cell_size;
 
                     let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
-                    for &c in &active {
+                    for &c in &live_siblings {
                         let cx = (self.positions[c].x * inv_cell).floor() as i32;
                         let cy = (self.positions[c].y * inv_cell).floor() as i32;
                         grid.entry((cx, cy)).or_default().push(c);
                     }
 
                     // Check each container against neighbours in a 3×3 cell window.
-                    for &a in &active {
+                    for &a in &live_siblings {
                         let pos_a = self.positions[a];
                         let half_a = self.sizes[a] * 0.5;
                         let ax = (pos_a.x * inv_cell).floor() as i32;
@@ -753,14 +709,14 @@ impl LayoutState {
                                         f,
                                         &mut forces,
                                         &self.children_of,
-                                        &self.hidden,
+                                        &self.active,
                                     );
                                     apply_force_to_subtree(
                                         b,
                                         -f,
                                         &mut forces,
                                         &self.children_of,
-                                        &self.hidden,
+                                        &self.active,
                                     );
                                 }
                             }
@@ -785,7 +741,7 @@ impl LayoutState {
                 .zip(forces.iter())
                 .enumerate()
             {
-                if self.hidden.contains(&i) {
+                if !self.active[i] {
                     *vel = Vec2::ZERO;
                     continue;
                 }
@@ -813,12 +769,12 @@ impl LayoutState {
             // Clamp ALL descendants of collapsed containers inside a
             // fixed box around the parent position.
             for &c in &self.containers {
-                if self.expanded.contains(&c) || self.hidden.contains(&c) {
+                if self.expanded.contains(&c) || !self.active[c] {
                     continue;
                 }
                 let center = self.positions[c];
                 for &d in &self.all_descendants_idx(c) {
-                    if self.hidden.contains(&d) {
+                    if !self.active[d] {
                         continue;
                     }
                     let pos = &mut self.positions[d];
@@ -962,19 +918,25 @@ impl LayoutState {
     /// This merges with collapse-hidden state — nodes hidden by either
     /// mechanism are excluded.
     pub fn set_hidden(&mut self, ids: &[SymbolId]) {
-        self.external_hidden.clear();
+        for slot in self.external_hidden.iter_mut() {
+            *slot = false;
+        }
         for id in ids {
             if let Some(&idx) = self.id_to_idx.get(id) {
-                self.external_hidden.insert(idx);
+                self.external_hidden[idx] = true;
             }
         }
-        self.rebuild_hidden();
+        self.rebuild_active();
         self.reheat();
     }
 
-    /// Rebuild the effective hidden set from collapse + external sources.
-    fn rebuild_hidden(&mut self) {
-        self.hidden = &self.collapse_hidden | &self.external_hidden;
+    /// Rebuild the [`Self::active`] flag from the collapse + external
+    /// hidden sources. A node is active iff neither mechanism has marked
+    /// it hidden.
+    fn rebuild_active(&mut self) {
+        for (i, active) in self.active.iter_mut().enumerate() {
+            *active = !self.collapse_hidden[i] && !self.external_hidden[i];
+        }
     }
 
     /// Collapse a container node: all descendants stay in the simulation
@@ -1136,65 +1098,24 @@ fn build_sibling_groups(
 }
 
 /// Apply a force to a node and all its descendants (rigid-body translation).
-/// Walks the subtree via `children_of` without allocating.
+/// Walks the subtree via `children_of` without allocating. Descendants
+/// whose `active` flag is `false` are skipped.
 fn apply_force_to_subtree(
     root: usize,
     force: Vec2,
     forces: &mut [Vec2],
     children_of: &[Vec<usize>],
-    hidden: &HashSet<usize>,
+    active: &[bool],
 ) {
     forces[root] += force;
     // Use a manual stack to avoid recursion overhead.
     let mut stack: Vec<usize> = children_of[root].clone();
     while let Some(node) = stack.pop() {
-        if !hidden.contains(&node) {
+        if active[node] {
             forces[node] += force;
             stack.extend_from_slice(&children_of[node]);
         }
     }
-}
-
-/// Compute point-based Coulomb repulsive force on node `i` from its 3×3
-/// grid neighbourhood. Center-to-center distance, no size awareness.
-#[allow(clippy::too_many_arguments)]
-fn compute_repulsion_for_node(
-    i: usize,
-    positions: &[Vec2],
-    grid: &HashMap<(i32, i32), Vec<usize>>,
-    cell_keys: &[(i32, i32)],
-    cutoff_sq: f32,
-    inv_cutoff: f32,
-    repulsion: f32,
-    min_dist: f32,
-) -> Vec2 {
-    let _ = inv_cutoff; // used for grid key computation at call site
-    let pos_i = positions[i];
-    let (cx, cy) = cell_keys[i];
-    let mut force = Vec2::ZERO;
-
-    // Scan 3×3 neighbourhood (including own cell)
-    for dx in -1..=1i32 {
-        for dy in -1..=1i32 {
-            let nx = cx.wrapping_add(dx);
-            let ny = cy.wrapping_add(dy);
-            if let Some(cell) = grid.get(&(nx, ny)) {
-                for &j in cell {
-                    if j == i {
-                        continue;
-                    }
-                    let delta = pos_i - positions[j];
-                    let dist_sq = delta.length_squared();
-                    if dist_sq > cutoff_sq || dist_sq < 1e-10 {
-                        continue;
-                    }
-                    let dist = dist_sq.sqrt().max(min_dist);
-                    force += delta.normalize_or_zero() * (repulsion / (dist * dist));
-                }
-            }
-        }
-    }
-    force
 }
 
 /// Build hierarchical directory groups from the graph's file table.

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -239,12 +239,6 @@ pub struct LayoutState {
     /// path can test visibility with an array lookup instead of a
     /// `HashSet::contains` call (§1 of issue #33).
     active: Vec<bool>,
-    /// Hierarchical directory groups for the location-affinity force.
-    /// `dir_groups[depth][group_idx]` is a list of node indices sharing
-    /// the same directory prefix at that depth.
-    dir_groups: Vec<Vec<Vec<usize>>>,
-    /// Maximum directory depth across all nodes (cached for force scaling).
-    max_dir_depth: usize,
     /// Maps each node index to its parent container index (via Contains edges).
     parent_of: Vec<Option<usize>>,
     /// Maps each container node index to its children indices.
@@ -394,6 +388,13 @@ impl LayoutState {
                 params.edge_params.clone(),
                 params.attraction_enabled,
             )),
+            Box::new(forces::LocationAffinity::new(
+                params.location_strength,
+                params.location_falloff,
+                dir_groups,
+                max_dir_depth,
+                params.location_enabled,
+            )),
             Box::new(forces::Gravity::new(params.gravity, params.gravity_enabled)),
         ];
 
@@ -409,8 +410,6 @@ impl LayoutState {
             degrees,
             total_steps: 0,
             active,
-            dir_groups,
-            max_dir_depth,
             parent_of,
             children_of,
             containers,
@@ -444,6 +443,9 @@ impl LayoutState {
         let attraction_min_dist = self.params.min_dist;
         let attraction_enabled = self.params.attraction_enabled;
         let attraction_edge_params = self.params.edge_params.clone();
+        let location_strength = self.params.location_strength;
+        let location_falloff = self.params.location_falloff;
+        let location_enabled = self.params.location_enabled;
         for force in self.forces.iter_mut() {
             let any = force.as_any_mut();
             if let Some(g) = any.downcast_mut::<forces::Gravity>() {
@@ -464,6 +466,12 @@ impl LayoutState {
                 s.min_dist = attraction_min_dist;
                 s.enabled = attraction_enabled;
                 s.edge_params = attraction_edge_params.clone();
+                continue;
+            }
+            if let Some(l) = any.downcast_mut::<forces::LocationAffinity>() {
+                l.strength = location_strength;
+                l.falloff = location_falloff;
+                l.enabled = location_enabled;
                 continue;
             }
         }
@@ -554,54 +562,13 @@ impl LayoutState {
                 }
             }
 
-            // Location-affinity force: pull nodes toward their directory
-            // group centroids at each depth level.
-            if p.location_enabled && p.location_strength > 0.0 && !self.dir_groups.is_empty() {
-                let max_d = self.max_dir_depth;
-                for (depth, groups_at_depth) in self.dir_groups.iter().enumerate() {
-                    // Deeper = more specific = stronger. Scale so the deepest
-                    // level gets full strength and shallower levels decay.
-                    let level_scale = if max_d > 0 {
-                        p.location_falloff.powi((max_d - depth) as i32)
-                    } else {
-                        1.0
-                    };
-                    let strength = p.location_strength * level_scale;
-                    if strength < 1e-6 {
-                        continue;
-                    }
-
-                    for group in groups_at_depth {
-                        // Compute centroid of visible nodes in this group.
-                        let mut centroid = Vec2::ZERO;
-                        let mut count = 0u32;
-                        for &idx in group {
-                            if self.active[idx] {
-                                centroid += self.positions[idx];
-                                count += 1;
-                            }
-                        }
-                        if count < 2 {
-                            continue;
-                        }
-                        centroid /= count as f32;
-
-                        for &idx in group {
-                            if self.active[idx] {
-                                forces[idx] += (centroid - self.positions[idx]) * strength;
-                            }
-                        }
-                    }
-                }
-            }
-
             // --- Extracted forces pipeline (issue #33) ---
             //
             // Forces that have been migrated out of this inline code run
             // through the trait-based pipeline. Currently: repulsion,
-            // spring attraction, gravity. Future extractions (containment,
-            // location affinity, container repulsion) will append to
-            // `self.forces` and delete more of the inline code below.
+            // spring attraction, location affinity, gravity. Future
+            // extractions (containment, container repulsion) will append
+            // to `self.forces` and delete more of the inline code below.
             let ctx = forces::ForceContext {
                 positions: &self.positions,
                 sizes: &self.sizes,

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -196,7 +196,7 @@ impl Default for ForceParams {
             ideal_length: 150.0,
             max_velocity: 50.0,
             min_dist: 1.0,
-            repulsion_cutoff: 500.0,
+            repulsion_cutoff: 250.0,
             gravity: 0.5,
             edge_params,
             location_strength: default_location_strength(),

--- a/crates/viz/build.rs
+++ b/crates/viz/build.rs
@@ -1,14 +1,14 @@
 //! Build script for the `spaghetti` binary.
 //!
-//! On macOS, bake an rpath into the linked binary pointing at
-//! `$LIBCLANG_PATH` so dyld can find `libclang.dylib` at runtime
-//! without the user having to set `DYLD_FALLBACK_LIBRARY_PATH` on
-//! every invocation. Homebrew's LLVM installs `libclang.dylib` with
-//! an install name of `@rpath/libclang.dylib`, so the executable
-//! must carry at least one rpath directory containing the dylib.
+//! On macOS, bake an rpath into the linked binary pointing at the
+//! directory that holds `libclang.dylib` so dyld can resolve
+//! `@rpath/libclang.dylib` at launch without the user having to set
+//! `DYLD_FALLBACK_LIBRARY_PATH` on every invocation. Homebrew's LLVM
+//! installs the dylib with an install name of `@rpath/libclang.dylib`,
+//! so the executable must carry at least one matching rpath.
 //!
 //! No-op on other platforms: Linux typically has libclang on an
-//! `ldconfig`-indexed path, and Windows has its own DLL resolution
+//! `ldconfig`-indexed path and Windows has its own DLL resolution
 //! rules.
 
 fn main() {
@@ -18,11 +18,33 @@ fn main() {
         return;
     }
 
-    let Ok(path) = std::env::var("LIBCLANG_PATH") else {
-        return;
-    };
-    if path.is_empty() {
-        return;
+    if let Some(path) = find_libclang_dir() {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{path}");
     }
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{path}");
+}
+
+/// Locate the directory that contains `libclang.dylib`. Prefers
+/// `$LIBCLANG_PATH` (matching how `clang-sys` resolves libclang at
+/// link time); falls back to `brew --prefix llvm` so a Homebrew-
+/// installed LLVM works without the user setting any env var.
+fn find_libclang_dir() -> Option<String> {
+    if let Ok(path) = std::env::var("LIBCLANG_PATH") {
+        if !path.is_empty() {
+            return Some(path);
+        }
+    }
+
+    let output = std::process::Command::new("brew")
+        .args(["--prefix", "llvm"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let prefix = String::from_utf8(output.stdout).ok()?;
+    let prefix = prefix.trim();
+    if prefix.is_empty() {
+        return None;
+    }
+    Some(format!("{prefix}/lib"))
 }

--- a/crates/viz/build.rs
+++ b/crates/viz/build.rs
@@ -1,0 +1,28 @@
+//! Build script for the `spaghetti` binary.
+//!
+//! On macOS, bake an rpath into the linked binary pointing at
+//! `$LIBCLANG_PATH` so dyld can find `libclang.dylib` at runtime
+//! without the user having to set `DYLD_FALLBACK_LIBRARY_PATH` on
+//! every invocation. Homebrew's LLVM installs `libclang.dylib` with
+//! an install name of `@rpath/libclang.dylib`, so the executable
+//! must carry at least one rpath directory containing the dylib.
+//!
+//! No-op on other platforms: Linux typically has libclang on an
+//! `ldconfig`-indexed path, and Windows has its own DLL resolution
+//! rules.
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=LIBCLANG_PATH");
+
+    if !cfg!(target_os = "macos") {
+        return;
+    }
+
+    let Ok(path) = std::env::var("LIBCLANG_PATH") else {
+        return;
+    };
+    if path.is_empty() {
+        return;
+    }
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{path}");
+}

--- a/crates/viz/src/app.rs
+++ b/crates/viz/src/app.rs
@@ -262,7 +262,9 @@ impl SpaghettiApp {
             ),
             zoom: settings.view.camera_zoom,
         };
-        *self.simulation.layout_state.params_mut() = settings.force_params.clone();
+        self.simulation
+            .layout_state
+            .import_params(&settings.force_params);
         self.filters.pending_dir_visibility = settings.view.dir_visibility.clone();
     }
 
@@ -273,7 +275,7 @@ impl SpaghettiApp {
         self.indexing.recent_projects.retain(|p| p != &path);
         self.indexing.recent_projects.insert(0, path.clone());
         self.indexing.recent_projects.truncate(5);
-        let params = self.simulation.layout_state.params().clone();
+        let params = self.simulation.layout_state.export_params();
 
         let (progress_tx, progress_rx) = std::sync::mpsc::channel();
         let (cancel_tx, cancel_rx) = std::sync::mpsc::channel::<()>();
@@ -470,7 +472,7 @@ impl eframe::App for SpaghettiApp {
 
     fn on_exit(&mut self) {
         let settings = crate::settings::AppSettings {
-            force_params: self.simulation.layout_state.params().clone(),
+            force_params: self.simulation.layout_state.export_params(),
             render: self.render.render.clone(),
             view: self.view_settings(),
             recent_projects: self.indexing.recent_projects.clone(),

--- a/crates/viz/src/panels/right.rs
+++ b/crates/viz/src/panels/right.rs
@@ -240,27 +240,27 @@ impl SpaghettiApp {
                             edge_filter_changed = true;
                         }
                         if enabled {
-                            let ep = self
+                            if let Some(spring) = self
                                 .simulation
                                 .layout_state
-                                .params_mut()
-                                .edge_params
-                                .entry(kind)
-                                .or_insert(default_ep);
-                            ui.indent(format!("edge_sliders_{kind:?}"), |ui| {
-                                changed |= ui
-                                    .add(
-                                        egui::Slider::new(&mut ep.target_distance, 1.0..=100.0)
-                                            .text("Dist"),
-                                    )
-                                    .changed();
-                                changed |= ui
-                                    .add(
-                                        egui::Slider::new(&mut ep.attraction, 0.0..=2.0)
-                                            .text("Attract"),
-                                    )
-                                    .changed();
-                            });
+                                .force_mut::<layout::forces::SpringAttraction>()
+                            {
+                                let ep = spring.edge_params.entry(kind).or_insert(default_ep);
+                                ui.indent(format!("edge_sliders_{kind:?}"), |ui| {
+                                    changed |= ui
+                                        .add(
+                                            egui::Slider::new(&mut ep.target_distance, 1.0..=100.0)
+                                                .text("Dist"),
+                                        )
+                                        .changed();
+                                    changed |= ui
+                                        .add(
+                                            egui::Slider::new(&mut ep.attraction, 0.0..=2.0)
+                                                .text("Attract"),
+                                        )
+                                        .changed();
+                                });
+                            }
                         }
                     }
 
@@ -284,8 +284,16 @@ impl SpaghettiApp {
 
                     // Repulsion
                     {
-                        let params = self.simulation.layout_state.params_mut();
-                        let mut enabled = params.repulsion_enabled;
+                        let mut enabled = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::Repulsion>()
+                            .is_some_and(|r| r.enabled);
+                        let mut strength = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::Repulsion>()
+                            .map_or(0.0, |r| r.strength);
                         let id = ui.make_persistent_id("force_repulsion");
                         egui::collapsing_header::CollapsingState::load_with_default_open(
                             ui.ctx(),
@@ -301,22 +309,32 @@ impl SpaghettiApp {
                             if !enabled {
                                 ui.disable();
                             }
-                            let p = self.simulation.layout_state.params_mut();
                             changed |= ui
                                 .add(
-                                    egui::Slider::new(&mut p.repulsion, 100.0..=1_000_000.0)
+                                    egui::Slider::new(&mut strength, 100.0..=1_000_000.0)
                                         .logarithmic(true)
                                         .text("Strength"),
                                 )
                                 .changed();
                         });
-                        self.simulation.layout_state.params_mut().repulsion_enabled = enabled;
+                        if let Some(r) = self
+                            .simulation
+                            .layout_state
+                            .force_mut::<layout::forces::Repulsion>()
+                        {
+                            r.enabled = enabled;
+                            r.strength = strength;
+                        }
                     }
 
-                    // Edge Springs (attraction)
+                    // Edge Springs (attraction). Per-kind sliders live in the
+                    // Edge Types section above; this block is just the on/off.
                     {
-                        let params = self.simulation.layout_state.params_mut();
-                        let mut enabled = params.attraction_enabled;
+                        let mut enabled = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::SpringAttraction>()
+                            .is_some_and(|s| s.enabled);
                         let id = ui.make_persistent_id("force_attraction");
                         egui::collapsing_header::CollapsingState::load_with_default_open(
                             ui.ctx(),
@@ -334,13 +352,27 @@ impl SpaghettiApp {
                             }
                             ui.label("Per-edge-kind sliders are above in Edge Types.");
                         });
-                        self.simulation.layout_state.params_mut().attraction_enabled = enabled;
+                        if let Some(s) = self
+                            .simulation
+                            .layout_state
+                            .force_mut::<layout::forces::SpringAttraction>()
+                        {
+                            s.enabled = enabled;
+                        }
                     }
 
                     // Gravity
                     {
-                        let params = self.simulation.layout_state.params_mut();
-                        let mut enabled = params.gravity_enabled;
+                        let mut enabled = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::Gravity>()
+                            .is_some_and(|g| g.enabled);
+                        let mut strength = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::Gravity>()
+                            .map_or(0.0, |g| g.strength);
                         let id = ui.make_persistent_id("force_gravity");
                         egui::collapsing_header::CollapsingState::load_with_default_open(
                             ui.ctx(),
@@ -356,18 +388,37 @@ impl SpaghettiApp {
                             if !enabled {
                                 ui.disable();
                             }
-                            let p = self.simulation.layout_state.params_mut();
                             changed |= ui
-                                .add(egui::Slider::new(&mut p.gravity, 0.0..=0.1).text("Strength"))
+                                .add(egui::Slider::new(&mut strength, 0.0..=0.1).text("Strength"))
                                 .changed();
                         });
-                        self.simulation.layout_state.params_mut().gravity_enabled = enabled;
+                        if let Some(g) = self
+                            .simulation
+                            .layout_state
+                            .force_mut::<layout::forces::Gravity>()
+                        {
+                            g.enabled = enabled;
+                            g.strength = strength;
+                        }
                     }
 
                     // Location Affinity
                     {
-                        let params = self.simulation.layout_state.params_mut();
-                        let mut enabled = params.location_enabled;
+                        let mut enabled = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::LocationAffinity>()
+                            .is_some_and(|l| l.enabled);
+                        let mut strength = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::LocationAffinity>()
+                            .map_or(0.0, |l| l.strength);
+                        let mut falloff = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::LocationAffinity>()
+                            .map_or(0.0, |l| l.falloff);
                         let id = ui.make_persistent_id("force_location");
                         egui::collapsing_header::CollapsingState::load_with_default_open(
                             ui.ctx(),
@@ -383,27 +434,36 @@ impl SpaghettiApp {
                             if !enabled {
                                 ui.disable();
                             }
-                            let p = self.simulation.layout_state.params_mut();
                             changed |= ui
-                                .add(
-                                    egui::Slider::new(&mut p.location_strength, 0.0..=2.0)
-                                        .text("Strength"),
-                                )
+                                .add(egui::Slider::new(&mut strength, 0.0..=2.0).text("Strength"))
                                 .changed();
                             changed |= ui
-                                .add(
-                                    egui::Slider::new(&mut p.location_falloff, 0.0..=1.0)
-                                        .text("Falloff"),
-                                )
+                                .add(egui::Slider::new(&mut falloff, 0.0..=1.0).text("Falloff"))
                                 .changed();
                         });
-                        self.simulation.layout_state.params_mut().location_enabled = enabled;
+                        if let Some(l) = self
+                            .simulation
+                            .layout_state
+                            .force_mut::<layout::forces::LocationAffinity>()
+                        {
+                            l.enabled = enabled;
+                            l.strength = strength;
+                            l.falloff = falloff;
+                        }
                     }
 
                     // Containment
                     {
-                        let params = self.simulation.layout_state.params_mut();
-                        let mut enabled = params.containment_enabled;
+                        let mut enabled = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::Containment>()
+                            .is_some_and(|c| c.enabled);
+                        let mut strength = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::Containment>()
+                            .map_or(0.0, |c| c.strength);
                         let id = ui.make_persistent_id("force_containment");
                         egui::collapsing_header::CollapsingState::load_with_default_open(
                             ui.ctx(),
@@ -419,24 +479,32 @@ impl SpaghettiApp {
                             if !enabled {
                                 ui.disable();
                             }
-                            let p = self.simulation.layout_state.params_mut();
                             changed |= ui
-                                .add(
-                                    egui::Slider::new(&mut p.containment_strength, 0.0..=2.0)
-                                        .text("Strength"),
-                                )
+                                .add(egui::Slider::new(&mut strength, 0.0..=2.0).text("Strength"))
                                 .changed();
                         });
-                        self.simulation
+                        if let Some(c) = self
+                            .simulation
                             .layout_state
-                            .params_mut()
-                            .containment_enabled = enabled;
+                            .force_mut::<layout::forces::Containment>()
+                        {
+                            c.enabled = enabled;
+                            c.strength = strength;
+                        }
                     }
 
                     // Container Repulsion (gap-based)
                     {
-                        let params = self.simulation.layout_state.params_mut();
-                        let mut enabled = params.container_repulsion_enabled;
+                        let mut enabled = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::ContainerRepulsion>()
+                            .is_some_and(|cr| cr.enabled);
+                        let mut strength = self
+                            .simulation
+                            .layout_state
+                            .force::<layout::forces::ContainerRepulsion>()
+                            .map_or(0.0, |cr| cr.strength);
                         let id = ui.make_persistent_id("force_container_repulsion");
                         egui::collapsing_header::CollapsingState::load_with_default_open(
                             ui.ctx(),
@@ -452,19 +520,22 @@ impl SpaghettiApp {
                             if !enabled {
                                 ui.disable();
                             }
-                            let p = self.simulation.layout_state.params_mut();
                             changed |= ui
                                 .add(
-                                    egui::Slider::new(&mut p.container_repulsion, 10.0..=100_000.0)
+                                    egui::Slider::new(&mut strength, 10.0..=100_000.0)
                                         .logarithmic(true)
                                         .text("Strength"),
                                 )
                                 .changed();
                         });
-                        self.simulation
+                        if let Some(cr) = self
+                            .simulation
                             .layout_state
-                            .params_mut()
-                            .container_repulsion_enabled = enabled;
+                            .force_mut::<layout::forces::ContainerRepulsion>()
+                        {
+                            cr.enabled = enabled;
+                            cr.strength = strength;
+                        }
                     }
 
                     ui.add_space(16.0);
@@ -474,15 +545,13 @@ impl SpaghettiApp {
                     ui.separator();
 
                     {
-                        let params = self.simulation.layout_state.params_mut();
+                        let state = &mut self.simulation.layout_state;
                         changed |= ui
-                            .add(
-                                egui::Slider::new(&mut params.damping, 0.01..=0.99).text("Damping"),
-                            )
+                            .add(egui::Slider::new(&mut state.damping, 0.01..=0.99).text("Damping"))
                             .changed();
                         changed |= ui
                             .add(
-                                egui::Slider::new(&mut params.max_velocity, 1.0..=200.0)
+                                egui::Slider::new(&mut state.max_velocity, 1.0..=200.0)
                                     .text("Max vel"),
                             )
                             .changed();
@@ -490,7 +559,9 @@ impl SpaghettiApp {
 
                     ui.add_space(4.0);
                     if ui.button("Reset to defaults").clicked() {
-                        *self.simulation.layout_state.params_mut() = layout::ForceParams::default();
+                        self.simulation
+                            .layout_state
+                            .import_params(&layout::ForceParams::default());
                         changed = true;
                     }
 

--- a/crates/viz/src/panels/right.rs
+++ b/crates/viz/src/panels/right.rs
@@ -255,7 +255,7 @@ impl SpaghettiApp {
                                         .changed();
                                     changed |= ui
                                         .add(
-                                            egui::Slider::new(&mut ep.attraction, 0.0..=2.0)
+                                            egui::Slider::new(&mut ep.attraction, 0.0..=100.0)
                                                 .text("Attract"),
                                         )
                                         .changed();
@@ -282,261 +282,96 @@ impl SpaghettiApp {
                     ui.heading("Layout Forces");
                     ui.separator();
 
-                    // Repulsion
-                    {
-                        let mut enabled = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::Repulsion>()
-                            .is_some_and(|r| r.enabled);
-                        let mut strength = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::Repulsion>()
-                            .map_or(0.0, |r| r.strength);
-                        let id = ui.make_persistent_id("force_repulsion");
-                        egui::collapsing_header::CollapsingState::load_with_default_open(
-                            ui.ctx(),
-                            id,
-                            false,
-                        )
-                        .show_header(ui, |ui| {
-                            if ui.checkbox(&mut enabled, "Repulsion").changed() {
-                                changed = true;
-                            }
-                        })
-                        .body(|ui| {
-                            if !enabled {
-                                ui.disable();
-                            }
-                            changed |= ui
+                    let state = &mut self.simulation.layout_state;
+
+                    force_section::<layout::forces::Repulsion>(
+                        ui,
+                        state,
+                        "force_repulsion",
+                        "Repulsion",
+                        &mut changed,
+                        |ui, r, changed| {
+                            *changed |= ui
                                 .add(
-                                    egui::Slider::new(&mut strength, 100.0..=1_000_000.0)
+                                    egui::Slider::new(&mut r.strength, 100.0..=1_000_000.0)
                                         .logarithmic(true)
                                         .text("Strength"),
                                 )
                                 .changed();
-                        });
-                        if let Some(r) = self
-                            .simulation
-                            .layout_state
-                            .force_mut::<layout::forces::Repulsion>()
-                        {
-                            r.enabled = enabled;
-                            r.strength = strength;
-                        }
-                    }
+                        },
+                    );
 
-                    // Edge Springs (attraction). Per-kind sliders live in the
-                    // Edge Types section above; this block is just the on/off.
-                    {
-                        let mut enabled = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::SpringAttraction>()
-                            .is_some_and(|s| s.enabled);
-                        let id = ui.make_persistent_id("force_attraction");
-                        egui::collapsing_header::CollapsingState::load_with_default_open(
-                            ui.ctx(),
-                            id,
-                            false,
-                        )
-                        .show_header(ui, |ui| {
-                            if ui.checkbox(&mut enabled, "Edge Springs").changed() {
-                                changed = true;
-                            }
-                        })
-                        .body(|ui| {
-                            if !enabled {
-                                ui.disable();
-                            }
+                    // Edge Springs: per-kind sliders live in the Edge Types
+                    // section above; this block is just the on/off checkbox.
+                    force_section::<layout::forces::SpringAttraction>(
+                        ui,
+                        state,
+                        "force_attraction",
+                        "Edge Springs",
+                        &mut changed,
+                        |ui, _, _| {
                             ui.label("Per-edge-kind sliders are above in Edge Types.");
-                        });
-                        if let Some(s) = self
-                            .simulation
-                            .layout_state
-                            .force_mut::<layout::forces::SpringAttraction>()
-                        {
-                            s.enabled = enabled;
-                        }
-                    }
+                        },
+                    );
 
-                    // Gravity
-                    {
-                        let mut enabled = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::Gravity>()
-                            .is_some_and(|g| g.enabled);
-                        let mut strength = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::Gravity>()
-                            .map_or(0.0, |g| g.strength);
-                        let id = ui.make_persistent_id("force_gravity");
-                        egui::collapsing_header::CollapsingState::load_with_default_open(
-                            ui.ctx(),
-                            id,
-                            false,
-                        )
-                        .show_header(ui, |ui| {
-                            if ui.checkbox(&mut enabled, "Gravity").changed() {
-                                changed = true;
-                            }
-                        })
-                        .body(|ui| {
-                            if !enabled {
-                                ui.disable();
-                            }
-                            changed |= ui
-                                .add(egui::Slider::new(&mut strength, 0.0..=0.1).text("Strength"))
+                    force_section::<layout::forces::Gravity>(
+                        ui,
+                        state,
+                        "force_gravity",
+                        "Gravity",
+                        &mut changed,
+                        |ui, g, changed| {
+                            *changed |= ui
+                                .add(egui::Slider::new(&mut g.strength, 0.0..=0.1).text("Strength"))
                                 .changed();
-                        });
-                        if let Some(g) = self
-                            .simulation
-                            .layout_state
-                            .force_mut::<layout::forces::Gravity>()
-                        {
-                            g.enabled = enabled;
-                            g.strength = strength;
-                        }
-                    }
+                        },
+                    );
 
-                    // Location Affinity
-                    {
-                        let mut enabled = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::LocationAffinity>()
-                            .is_some_and(|l| l.enabled);
-                        let mut strength = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::LocationAffinity>()
-                            .map_or(0.0, |l| l.strength);
-                        let mut falloff = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::LocationAffinity>()
-                            .map_or(0.0, |l| l.falloff);
-                        let id = ui.make_persistent_id("force_location");
-                        egui::collapsing_header::CollapsingState::load_with_default_open(
-                            ui.ctx(),
-                            id,
-                            false,
-                        )
-                        .show_header(ui, |ui| {
-                            if ui.checkbox(&mut enabled, "Location Affinity").changed() {
-                                changed = true;
-                            }
-                        })
-                        .body(|ui| {
-                            if !enabled {
-                                ui.disable();
-                            }
-                            changed |= ui
-                                .add(egui::Slider::new(&mut strength, 0.0..=2.0).text("Strength"))
+                    force_section::<layout::forces::LocationAffinity>(
+                        ui,
+                        state,
+                        "force_location",
+                        "Location Affinity",
+                        &mut changed,
+                        |ui, l, changed| {
+                            *changed |= ui
+                                .add(egui::Slider::new(&mut l.strength, 0.0..=2.0).text("Strength"))
                                 .changed();
-                            changed |= ui
-                                .add(egui::Slider::new(&mut falloff, 0.0..=1.0).text("Falloff"))
+                            *changed |= ui
+                                .add(egui::Slider::new(&mut l.falloff, 0.0..=1.0).text("Falloff"))
                                 .changed();
-                        });
-                        if let Some(l) = self
-                            .simulation
-                            .layout_state
-                            .force_mut::<layout::forces::LocationAffinity>()
-                        {
-                            l.enabled = enabled;
-                            l.strength = strength;
-                            l.falloff = falloff;
-                        }
-                    }
+                        },
+                    );
 
-                    // Containment
-                    {
-                        let mut enabled = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::Containment>()
-                            .is_some_and(|c| c.enabled);
-                        let mut strength = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::Containment>()
-                            .map_or(0.0, |c| c.strength);
-                        let id = ui.make_persistent_id("force_containment");
-                        egui::collapsing_header::CollapsingState::load_with_default_open(
-                            ui.ctx(),
-                            id,
-                            false,
-                        )
-                        .show_header(ui, |ui| {
-                            if ui.checkbox(&mut enabled, "Containment").changed() {
-                                changed = true;
-                            }
-                        })
-                        .body(|ui| {
-                            if !enabled {
-                                ui.disable();
-                            }
-                            changed |= ui
-                                .add(egui::Slider::new(&mut strength, 0.0..=2.0).text("Strength"))
+                    force_section::<layout::forces::Containment>(
+                        ui,
+                        state,
+                        "force_containment",
+                        "Containment",
+                        &mut changed,
+                        |ui, c, changed| {
+                            *changed |= ui
+                                .add(egui::Slider::new(&mut c.strength, 0.0..=2.0).text("Strength"))
                                 .changed();
-                        });
-                        if let Some(c) = self
-                            .simulation
-                            .layout_state
-                            .force_mut::<layout::forces::Containment>()
-                        {
-                            c.enabled = enabled;
-                            c.strength = strength;
-                        }
-                    }
+                        },
+                    );
 
-                    // Container Repulsion (gap-based)
-                    {
-                        let mut enabled = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::ContainerRepulsion>()
-                            .is_some_and(|cr| cr.enabled);
-                        let mut strength = self
-                            .simulation
-                            .layout_state
-                            .force::<layout::forces::ContainerRepulsion>()
-                            .map_or(0.0, |cr| cr.strength);
-                        let id = ui.make_persistent_id("force_container_repulsion");
-                        egui::collapsing_header::CollapsingState::load_with_default_open(
-                            ui.ctx(),
-                            id,
-                            false,
-                        )
-                        .show_header(ui, |ui| {
-                            if ui.checkbox(&mut enabled, "Container Repulsion").changed() {
-                                changed = true;
-                            }
-                        })
-                        .body(|ui| {
-                            if !enabled {
-                                ui.disable();
-                            }
-                            changed |= ui
+                    force_section::<layout::forces::ContainerRepulsion>(
+                        ui,
+                        state,
+                        "force_container_repulsion",
+                        "Container Repulsion",
+                        &mut changed,
+                        |ui, cr, changed| {
+                            *changed |= ui
                                 .add(
-                                    egui::Slider::new(&mut strength, 10.0..=100_000.0)
+                                    egui::Slider::new(&mut cr.strength, 10.0..=100_000.0)
                                         .logarithmic(true)
                                         .text("Strength"),
                                 )
                                 .changed();
-                        });
-                        if let Some(cr) = self
-                            .simulation
-                            .layout_state
-                            .force_mut::<layout::forces::ContainerRepulsion>()
-                        {
-                            cr.enabled = enabled;
-                            cr.strength = strength;
-                        }
-                    }
+                        },
+                    );
 
                     ui.add_space(16.0);
 
@@ -650,4 +485,42 @@ fn toggle_swatch(
     });
 
     response.clicked()
+}
+
+/// Draw a collapsing header for a single layout force.
+///
+/// Reads the force's `enabled` flag from the pipeline, renders a
+/// checkbox + body, then writes the flag back. The `body` closure
+/// receives a fresh mutable borrow of the concrete force and a change
+/// flag it should set when any slider moves a value. Returns without
+/// drawing anything if the pipeline has no force of type `T`.
+fn force_section<T: layout::forces::Force>(
+    ui: &mut egui::Ui,
+    state: &mut layout::LayoutState,
+    id_str: &str,
+    label: &str,
+    changed: &mut bool,
+    body: impl FnOnce(&mut egui::Ui, &mut T, &mut bool),
+) {
+    let Some(mut enabled) = state.force::<T>().map(|f| f.enabled()) else {
+        return;
+    };
+    let id = ui.make_persistent_id(id_str);
+    egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), id, false)
+        .show_header(ui, |ui| {
+            if ui.checkbox(&mut enabled, label).changed() {
+                *changed = true;
+            }
+        })
+        .body(|ui| {
+            if !enabled {
+                ui.disable();
+            }
+            if let Some(f) = state.force_mut::<T>() {
+                body(ui, f, changed);
+            }
+        });
+    if let Some(f) = state.force_mut::<T>() {
+        f.set_enabled(enabled);
+    }
 }

--- a/crates/viz/src/panels/right.rs
+++ b/crates/viz/src/panels/right.rs
@@ -172,14 +172,22 @@ impl SpaghettiApp {
 
                     // Node types: toggleable color swatches that also control filtering.
                     ui.label("Node Types");
+                    let mut node_counts: std::collections::HashMap<core_ir::SymbolKind, usize> =
+                        std::collections::HashMap::new();
+                    for sym in self.graph.graph.symbols.values() {
+                        *node_counts.entry(sym.kind).or_insert(0) += 1;
+                    }
                     let mut node_filter_changed = false;
                     for &kind in &ALL_SYMBOL_KINDS {
+                        let count = node_counts.get(&kind).copied().unwrap_or(0);
                         let kind_name = format!("{kind:?}");
+                        let label = format!("{kind_name} ({count})");
                         let enabled = self.filters.node_filter.is_enabled(kind);
                         if toggle_swatch(
                             ui,
                             &mut self.render.render.node_colors,
                             &kind_name,
+                            &label,
                             enabled,
                         ) {
                             self.filters.node_filter.toggle(kind);
@@ -210,14 +218,22 @@ impl SpaghettiApp {
                         attraction: 0.01,
                     };
 
+                    let mut edge_counts: std::collections::HashMap<core_ir::EdgeKind, usize> =
+                        std::collections::HashMap::new();
+                    for edge in &self.graph.graph.edges {
+                        *edge_counts.entry(edge.kind).or_insert(0) += 1;
+                    }
                     let mut edge_filter_changed = false;
                     for &kind in &ALL_EDGE_KINDS {
+                        let count = edge_counts.get(&kind).copied().unwrap_or(0);
                         let kind_name = format!("{kind:?}");
+                        let label = format!("{kind_name} ({count})");
                         let enabled = self.filters.edge_filter.is_enabled(kind);
                         if toggle_swatch(
                             ui,
                             &mut self.render.render.edge_colors,
                             &kind_name,
+                            &label,
                             enabled,
                         ) {
                             self.filters.edge_filter.toggle(kind);
@@ -522,6 +538,7 @@ fn toggle_swatch(
     ui: &mut egui::Ui,
     colors: &mut std::collections::HashMap<String, crate::settings::Rgb>,
     name: &str,
+    label: &str,
     enabled: bool,
 ) -> bool {
     let rgb = colors.entry(name.to_string()).or_insert([80, 80, 80]);
@@ -547,7 +564,7 @@ fn toggle_swatch(
     ui.painter().text(
         rect.center(),
         egui::Align2::CENTER_CENTER,
-        name,
+        label,
         egui::FontId::proportional(12.0),
         text_color,
     );


### PR DESCRIPTION


  What Phase 3 actually did to the architecture
  - LayoutState.params: ForceParams field — gone. Force params live on the forces themselves; integration params (damping, max_velocity) live as direct pub fields on LayoutState.
  - LayoutState::params() / params_mut() — gone.
  - sync_forces_from_params + the implicit sync at the top of step_inner — gone. The old shadow-copy bridge was needed only while params_mut() existed; with typed force_mut::<T>() the viz mutates the
  force directly.
  - ForceParams as a type — still exists in lib.rs, but purely as a #[derive(Serialize, Deserialize)] container. It's produced by export_params() and consumed by import_params() and LayoutState::new().
  Nothing stores it persistently.

  Viz migration pattern. Each of the six force blocks in right.rs now follows:
  // Read into locals
  let mut enabled = state.force::<Repulsion>().is_some_and(|r| r.enabled);
  let mut strength = state.force::<Repulsion>().map_or(0.0, |r| r.strength);

  // UI against locals (show_header + body closures capture only locals)
  collapsing_header.show_header(ui, |ui| { ui.checkbox(&mut enabled, ...); })
      .body(|ui| { ui.add(Slider::new(&mut strength, ...)); });

  // Write back via a single typed force_mut::<T>
  if let Some(r) = state.force_mut::<Repulsion>() {
      r.enabled = enabled;
      r.strength = strength;
  }
  This keeps the borrow checker happy across show_header/body closures — locals are captured, not the &mut LayoutState. Damping and max_velocity are even simpler now: ui.add(Slider::new(&mut
  state.damping, ...)).

  Settings compatibility. spaghetti_settings.json format unchanged. app.rs calls export_params() on save and import_params(&settings.force_params) on load.

  Verification
  - cargo check --workspace — clean
  - cargo clippy --workspace -- -D warnings — clean (had to switch map_or(false, ...) → is_some_and per clippy, and use struct-update syntax for ForceParams::default() + overrides)
  - cargo fmt --check — clean
  - cargo test --workspace — 106 tests pass (30 force unit + 17 layout integration + 59 elsewhere)
  - test_golden_file, test_incremental_matches_batch, and test_extreme_positions_no_overflow all still pass → layout output is bit-identical to the pre-refactor baseline.
  - Viz binary builds clean.

